### PR TITLE
Prefer direct pin connections during single-component packing

### DIFF
--- a/lib/utils/networkFiltering.ts
+++ b/lib/utils/networkFiltering.ts
@@ -119,24 +119,15 @@ export function createFilteredNetworkMapping(
     }
   }
 
-  // Process strong connections - these form their own networks
+  // Process strong connections - these override net connections and form their own networks
   for (const [connKey, connected] of Object.entries(
     inputProblem.pinStrongConnMap,
   )) {
     if (!connected) continue
     const pins = connKey.split("-")
     if (pins.length === 2 && pins[0] && pins[1]) {
-      // If either pin already has a net connection, use that network for both
-      const existingNet =
-        pinToNetworkMap.get(pins[0]) || pinToNetworkMap.get(pins[1])
-      if (existingNet) {
-        pinToNetworkMap.set(pins[0], existingNet)
-        pinToNetworkMap.set(pins[1], existingNet)
-      } else {
-        // Otherwise, use the connection itself as the network
-        pinToNetworkMap.set(pins[0], connKey)
-        pinToNetworkMap.set(pins[1], connKey)
-      }
+      pinToNetworkMap.set(pins[0], connKey)
+      pinToNetworkMap.set(pins[1], connKey)
     }
   }
 

--- a/tests/networkFiltering.test.ts
+++ b/tests/networkFiltering.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "bun:test"
+import { createFilteredNetworkMapping } from "../lib/utils/networkFiltering"
+import type { InputProblem } from "../lib/types/InputProblem"
+
+describe("createFilteredNetworkMapping", () => {
+  it("prefers direct connections over net connections", () => {
+    const inputProblem: InputProblem = {
+      chipMap: {
+        A: { chipId: "A", pins: ["A.p1"], size: { x: 1, y: 1 } },
+        B: { chipId: "B", pins: ["B.p1"], size: { x: 1, y: 1 } },
+      },
+      chipPinMap: {
+        "A.p1": { pinId: "A.p1", offset: { x: 0, y: 0 }, side: "x+" },
+        "B.p1": { pinId: "B.p1", offset: { x: 0, y: 0 }, side: "x-" },
+      },
+      netMap: { N1: { netId: "N1" } },
+      pinStrongConnMap: { "A.p1-B.p1": true },
+      netConnMap: { "A.p1-N1": true, "B.p1-N1": true },
+      chipGap: 0,
+      partitionGap: 0,
+    }
+
+    const { pinToNetworkMap } = createFilteredNetworkMapping(inputProblem)
+    expect(pinToNetworkMap.get("A.p1")).toBe("A.p1-B.p1")
+    expect(pinToNetworkMap.get("B.p1")).toBe("A.p1-B.p1")
+  })
+})


### PR DESCRIPTION
related to #20 

## Summary
- Ensure strong pin-to-pin links override net connections during network filtering
- Add test verifying direct connections take precedence over nets

## Testing
- `bun test tests/networkFiltering.test.ts`
- `bun test tests` *(fails: Invalid JSX Element errors in multiple LayoutPipelineSolver tests)*

------
https://chatgpt.com/codex/tasks/task_b_68b9f076c01c832e96b912fb1e35a1b1