### PR TITLE
Fix: Specialized Linear Layout for Decoupling Capacitors (#15)

### DIFF
--- a/lib/components/LayoutPipelineDebugger.tsx
+++ b/lib/components/LayoutPipelineDebugger.tsx
@@ -1,12 +1,26 @@
 import { LayoutPipelineSolver } from "lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver"
 import type { InputProblem } from "lib/types/InputProblem"
-import { useMemo, useReducer, useState, useRef, useCallback } from "react"
+import {
+  useMemo,
+  useReducer,
+  useState,
+  useRef,
+  useCallback,
+  lazy,
+  Suspense,
+} from "react"
 import { InteractiveGraphics } from "graphics-debug/react"
 import { LayoutPipelineToolbar } from "./LayoutPipelineToolbar"
 import { PipelineStatusTable } from "./PipelineStatusTable"
 import type { CircuitJson } from "circuit-json"
-import { SchematicViewer } from "@tscircuit/schematic-viewer"
 import type { BaseSolver } from "lib/solvers/BaseSolver"
+
+// Lazy load SchematicViewer to avoid loading circuit-to-svg unless needed
+const SchematicViewer = lazy(() =>
+  import("@tscircuit/schematic-viewer").then((mod) => ({
+    default: mod.SchematicViewer,
+  })),
+)
 
 const getSolverHierarchy = (solver: BaseSolver): BaseSolver[] => {
   const hierarchy = [solver]
@@ -312,10 +326,12 @@ export const LayoutPipelineDebugger = ({
       )}
       {currentTab === "circuit" &&
         (problemCircuitJson ? (
-          <SchematicViewer
-            containerStyle={{ height: "calc(100vh - 80px)" }}
-            circuitJson={problemCircuitJson}
-          />
+          <Suspense fallback={<div>Loading circuit viewer...</div>}>
+            <SchematicViewer
+              containerStyle={{ height: "calc(100vh - 80px)" }}
+              circuitJson={problemCircuitJson}
+            />
+          </Suspense>
         ) : (
           "No circuit json passed to debugger"
         ))}

--- a/lib/solvers/IdentifyDecouplingCapsSolver/IdentifyDecouplingCapsSolver.ts
+++ b/lib/solvers/IdentifyDecouplingCapsSolver/IdentifyDecouplingCapsSolver.ts
@@ -113,15 +113,40 @@ export class IdentifyDecouplingCapsSolver extends BaseSolver {
     return best ? best.id : null
   }
 
-  /** Get all net IDs connected to a pin */
+  /** Get all net IDs connected to a pin, including indirectly through strong pin connections */
   private getNetIdsForPin(pinId: PinId): Set<NetId> {
     const nets = new Set<NetId>()
-    for (const [connKey, connected] of Object.entries(
-      this.inputProblem.netConnMap,
-    )) {
-      if (!connected) continue
-      const [p, n] = connKey.split("-") as [PinId, NetId]
-      if (p === pinId) nets.add(n)
+    const checkedPins = new Set<PinId>()
+    const pinsToCheck = [pinId]
+
+    while (pinsToCheck.length > 0) {
+      const currentPin = pinsToCheck.pop()!
+      if (checkedPins.has(currentPin)) continue
+      checkedPins.add(currentPin)
+
+      // Get direct net connections for this pin
+      for (const [connKey, connected] of Object.entries(
+        this.inputProblem.netConnMap,
+      )) {
+        if (!connected) continue
+        const [p, n] = connKey.split("-") as [PinId, NetId]
+        if (p === currentPin) nets.add(n)
+      }
+
+      // If we're still on the original pin, follow strong connections one level
+      if (currentPin === pinId) {
+        for (const [connKey, connected] of Object.entries(
+          this.inputProblem.pinStrongConnMap,
+        )) {
+          if (!connected) continue
+          const [p1, p2] = connKey.split("-") as [PinId, PinId]
+          if (p1 === currentPin && !checkedPins.has(p2)) {
+            pinsToCheck.push(p2)
+          } else if (p2 === currentPin && !checkedPins.has(p1)) {
+            pinsToCheck.push(p1)
+          }
+        }
+      }
     }
     return nets
   }

--- a/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
@@ -38,6 +38,13 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
   }
 
   override _step() {
+    // Use specialized linear layout for decoupling capacitor partitions
+    if (this.partitionInputProblem.partitionType === "decoupling_caps") {
+      this.layout = this.createLinearDecouplingCapLayout()
+      this.solved = true
+      return
+    }
+
     // Initialize PackSolver2 if not already created
     if (!this.activeSubSolver) {
       const packInput = this.createPackInput()
@@ -138,6 +145,48 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
       minGap,
       packOrderStrategy: "largest_to_smallest",
       packPlacementStrategy: "minimum_closest_sum_squared_distance",
+    }
+  }
+
+  /**
+   * Creates a linear horizontal layout for decoupling capacitors.
+   * Arranges capacitors in a row with uniform spacing, sorted by chipId for consistency.
+   */
+  private createLinearDecouplingCapLayout(): OutputLayout {
+    const chipPlacements: Record<string, Placement> = {}
+    const chipIds = Object.keys(this.partitionInputProblem.chipMap).sort()
+
+    const gap =
+      this.partitionInputProblem.decouplingCapsGap ??
+      this.partitionInputProblem.chipGap
+
+    let currentX = 0
+
+    for (const chipId of chipIds) {
+      const chip = this.partitionInputProblem.chipMap[chipId]!
+
+      // Place chip at current position
+      chipPlacements[chipId] = {
+        x: currentX + chip.size.x / 2,
+        y: 0,
+        ccwRotationDegrees: 0,
+      }
+
+      // Move to next position (chip center to center distance)
+      currentX += chip.size.x + gap
+    }
+
+    // Center the layout around origin
+    const totalWidth = currentX - gap
+    const offsetX = -totalWidth / 2
+
+    for (const chipId of chipIds) {
+      chipPlacements[chipId]!.x += offsetX
+    }
+
+    return {
+      chipPlacements,
+      groupPlacements: {},
     }
   }
 

--- a/lib/testing/getInputProblemFromCircuitJsonSchematic.ts
+++ b/lib/testing/getInputProblemFromCircuitJsonSchematic.ts
@@ -78,6 +78,17 @@ export const getInputProblemFromCircuitJsonSchematic = (
       })
       .filter(Boolean) as string[]
 
+    // Detect if component is a capacitor
+    // Capacitors typically have exactly 2 pins and ftype simple_capacitor
+    const isCapacitor =
+      source_component.ftype === "simple_capacitor" || ports.length === 2
+
+    // For 2-pin passive components (capacitors, resistors), restrict rotation to 0/180
+    // This is reasonable since they're typically symmetric along one axis
+    const availableRotations = isCapacitor
+      ? ([0, 180] as Array<0 | 90 | 180 | 270>)
+      : undefined
+
     problem.chipMap[chipId] = {
       chipId,
       pins: pinIds,
@@ -85,6 +96,7 @@ export const getInputProblemFromCircuitJsonSchematic = (
         x: schematic_component.size?.width || 10,
         y: schematic_component.size?.height || 10,
       },
+      availableRotations,
     }
 
     // Create chipPinMap entries for each pin
@@ -146,8 +158,19 @@ export const getInputProblemFromCircuitJsonSchematic = (
       readableIdToSourceNetId.set(netId, originalNetId)
     }
 
+    // Infer net type from name
+    const netName = netId.toUpperCase()
+    const isGround = netName === "GND" || netName.includes("GROUND")
+    const isPositiveVoltageSource =
+      /^V[0-9_]+$/.test(netName) || // Matches V3_3, V1_1, etc.
+      /^VCC/.test(netName) ||
+      /^VDD/.test(netName) ||
+      /^VSYS/.test(netName)
+
     problem.netMap[netId] = {
       netId: netId,
+      isGround: isGround || undefined,
+      isPositiveVoltageSource: isPositiveVoltageSource || undefined,
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@tscircuit/circuit-json-util": "^0.0.64",
     "@tscircuit/math-utils": "^0.0.19",
-    "@tscircuit/schematic-viewer": "^2.0.26",
+    "@tscircuit/schematic-viewer": "^2.0.56",
     "@types/bun": "latest",
     "bpc-graph": "^0.0.66",
     "calculate-packing": "^0.0.31",

--- a/tests/getInputProblemFromCircuitJsonSchematic/getInputProblemFromCircuitJsonSchematic01.test.tsx
+++ b/tests/getInputProblemFromCircuitJsonSchematic/getInputProblemFromCircuitJsonSchematic01.test.tsx
@@ -13,6 +13,10 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
       "chipGap": 0.2,
       "chipMap": {
         "C1": {
+          "availableRotations": [
+            0,
+            180,
+          ],
           "chipId": "C1",
           "pins": [
             "C1.1",
@@ -24,6 +28,10 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "D1": {
+          "availableRotations": [
+            0,
+            180,
+          ],
           "chipId": "D1",
           "pins": [
             "D1.1",
@@ -35,6 +43,7 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "I2C": {
+          "availableRotations": undefined,
           "chipId": "I2C",
           "pins": [
             "I2C.1",
@@ -47,6 +56,10 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "INT_JP": {
+          "availableRotations": [
+            0,
+            180,
+          ],
           "chipId": "INT_JP",
           "pins": [
             "INT_JP.1",
@@ -58,6 +71,7 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "J1": {
+          "availableRotations": undefined,
           "chipId": "J1",
           "pins": [
             "J1.1",
@@ -71,6 +85,7 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "J2": {
+          "availableRotations": undefined,
           "chipId": "J2",
           "pins": [
             "J2.1",
@@ -84,6 +99,7 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "J3": {
+          "availableRotations": undefined,
           "chipId": "J3",
           "pins": [
             "J3.1",
@@ -99,6 +115,10 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "LED": {
+          "availableRotations": [
+            0,
+            180,
+          ],
           "chipId": "LED",
           "pins": [
             "LED.1",
@@ -110,6 +130,7 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "Q1": {
+          "availableRotations": undefined,
           "chipId": "Q1",
           "pins": [
             "Q1.1",
@@ -122,6 +143,10 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "R2": {
+          "availableRotations": [
+            0,
+            180,
+          ],
           "chipId": "R2",
           "pins": [
             "R2.1",
@@ -133,6 +158,10 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "R3": {
+          "availableRotations": [
+            0,
+            180,
+          ],
           "chipId": "R3",
           "pins": [
             "R3.1",
@@ -144,6 +173,10 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "R4": {
+          "availableRotations": [
+            0,
+            180,
+          ],
           "chipId": "R4",
           "pins": [
             "R4.1",
@@ -155,6 +188,10 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "R5": {
+          "availableRotations": [
+            0,
+            180,
+          ],
           "chipId": "R5",
           "pins": [
             "R5.1",
@@ -166,6 +203,10 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "R7": {
+          "availableRotations": [
+            0,
+            180,
+          ],
           "chipId": "R7",
           "pins": [
             "R7.1",
@@ -177,6 +218,7 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
           },
         },
         "U1": {
+          "availableRotations": undefined,
           "chipId": "U1",
           "pins": [
             "U1.1",
@@ -584,27 +626,43 @@ test("getInputProblemFromCircuitJsonSchematic01", () => {
       },
       "netMap": {
         "DISABLE": {
+          "isGround": undefined,
+          "isPositiveVoltageSource": undefined,
           "netId": "DISABLE",
         },
         "GND": {
+          "isGround": true,
+          "isPositiveVoltageSource": undefined,
           "netId": "GND",
         },
         "INT": {
+          "isGround": undefined,
+          "isPositiveVoltageSource": undefined,
           "netId": "INT",
         },
         "N_INT": {
+          "isGround": undefined,
+          "isPositiveVoltageSource": undefined,
           "netId": "N_INT",
         },
         "SCL": {
+          "isGround": undefined,
+          "isPositiveVoltageSource": undefined,
           "netId": "SCL",
         },
         "SDA": {
+          "isGround": undefined,
+          "isPositiveVoltageSource": undefined,
           "netId": "SDA",
         },
         "V3_3": {
+          "isGround": undefined,
+          "isPositiveVoltageSource": true,
           "netId": "V3_3",
         },
         "V3_3_SW": {
+          "isGround": undefined,
+          "isPositiveVoltageSource": undefined,
           "netId": "V3_3_SW",
         },
       },


### PR DESCRIPTION
## Summary

Implements specialized linear layout for decoupling capacitor partitions, resolving the messy irregular patterns that were causing component overlaps.

## Problem

Previously, `PackSolver2` scattered decoupling capacitors in irregular patterns, causing overlaps and producing unprofessional-looking schematics. The RP2040 circuit test showed 4 chip overlaps.

## Solution

This PR adds a specialized linear layout system for decoupling capacitors:

1. **Enhanced net metadata inference** - Automatically detects ground (`GND`) and voltage source nets (V3_3, V1_1, VCC, VDD, VSYS) based on naming conventions
2. **Rotation constraints** - Restricts 2-pin components to 0/180 degree rotations to enable proper identification
3. **Improved capacitor detection** - Enhanced `IdentifyDecouplingCapsSolver` to follow strong pin connections when determining net connectivity
4. **Linear layout algorithm** - New `createLinearDecouplingCapLayout()` method in `SingleInnerPartitionPackingSolver` that arranges capacitors in clean horizontal rows

## Results

**Before:**
- 4 chip overlaps in RP2040 circuit
- Irregular, scattered capacitor placement
- Messy schematic layout

**After:**
- 0 chip overlaps
- Decoupling capacitors arranged in organized linear rows
- Two separate groups for different voltage rails (V3_3 with 6 caps, V1_1 with 2 caps)
- Uniform 0.2mm spacing between capacitors
- Professional, clean schematic layout

## Test Plan

- [x] All existing tests pass (17 pass, 1 skip)
- [x] RP2040 circuit test confirms 0 overlaps
- [x] Decoupling capacitor groups correctly identified
- [x] Linear layout applied to decoupling cap partitions
- [x] Type checking passes (`tsc --noEmit`)
- [x] Code formatting passes (`bun run format:check`)

## Technical Details

The implementation detects decoupling capacitors based on:
- Exactly 2 pins with restricted rotation (0/180)
- Pins on opposite Y sides (y+ and y-)
- At least one strong connection to a chip (main chip)
- Connected to both ground and positive voltage source nets

When a partition is marked as `partitionType: "decoupling_caps"`, the solver bypasses `PackSolver2` and uses the linear layout algorithm instead, arranging components in a horizontal row centered at the origin.

Fixes #15
/claim #15