### PR TITLE
feat: linear horizontal layout for decoupling caps

### DIFF
--- a/generate_preview.ts
+++ b/generate_preview.ts
@@ -98,8 +98,12 @@ const viewBoxHeight = maxHeight + 1
 
 // 生成 SVG
 const svgParts: string[] = []
-svgParts.push(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="${-viewBoxWidth/2} ${-viewBoxHeight/2} ${viewBoxWidth} ${viewBoxHeight}" width="800" height="400">`)
-svgParts.push(`  <rect x="${-viewBoxWidth/2}" y="${-viewBoxHeight/2}" width="${viewBoxWidth}" height="${viewBoxHeight}" fill="#f5f5f5"/>`)
+svgParts.push(
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${-viewBoxWidth / 2} ${-viewBoxHeight / 2} ${viewBoxWidth} ${viewBoxHeight}" width="800" height="400">`,
+)
+svgParts.push(
+  `  <rect x="${-viewBoxWidth / 2}" y="${-viewBoxHeight / 2}" width="${viewBoxWidth}" height="${viewBoxHeight}" fill="#f5f5f5"/>`,
+)
 
 // 绘制每个电容
 for (const id of chipIds) {
@@ -107,18 +111,28 @@ for (const id of chipIds) {
   const chip = problem.chipMap[id]!
   const halfWidth = chip.size.x / 2
   const halfHeight = chip.size.y / 2
-  
+
   const x = placement.x - halfWidth
   const y = placement.y - halfHeight
-  
-  svgParts.push(`  <rect x="${x.toFixed(2)}" y="${y.toFixed(2)}" width="${chip.size.x}" height="${chip.size.y}" fill="#4a90d9" stroke="#2c5a8c" stroke-width="0.05" rx="0.1"/>`)
-  svgParts.push(`  <text x="${placement.x.toFixed(2)}" y="${placement.y.toFixed(2)}" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="0.3" font-family="Arial">${id}</text>`)
-  svgParts.push(`  <text x="${placement.x.toFixed(2)}" y="${(placement.y + halfHeight + 0.4).toFixed(2)}" text-anchor="middle" fill="#333" font-size="0.2" font-family="Arial">x:${placement.x.toFixed(2)}, y:${placement.y.toFixed(2)}</text>`)
+
+  svgParts.push(
+    `  <rect x="${x.toFixed(2)}" y="${y.toFixed(2)}" width="${chip.size.x}" height="${chip.size.y}" fill="#4a90d9" stroke="#2c5a8c" stroke-width="0.05" rx="0.1"/>`,
+  )
+  svgParts.push(
+    `  <text x="${placement.x.toFixed(2)}" y="${placement.y.toFixed(2)}" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="0.3" font-family="Arial">${id}</text>`,
+  )
+  svgParts.push(
+    `  <text x="${placement.x.toFixed(2)}" y="${(placement.y + halfHeight + 0.4).toFixed(2)}" text-anchor="middle" fill="#333" font-size="0.2" font-family="Arial">x:${placement.x.toFixed(2)}, y:${placement.y.toFixed(2)}</text>`,
+  )
 }
 
 // 添加标题
-svgParts.push(`  <text x="0" y="${(-viewBoxHeight/2 + 0.3).toFixed(2)}" text-anchor="middle" fill="#333" font-size="0.25" font-family="Arial" font-weight="bold">Decoupling Capacitors Linear Layout</text>`)
-svgParts.push(`  <text x="0" y="${(-viewBoxHeight/2 + 0.6).toFixed(2)}" text-anchor="middle" fill="#666" font-size="0.18" font-family="Arial">5 caps arranged horizontally with 0.3 gap</text>`)
+svgParts.push(
+  `  <text x="0" y="${(-viewBoxHeight / 2 + 0.3).toFixed(2)}" text-anchor="middle" fill="#333" font-size="0.25" font-family="Arial" font-weight="bold">Decoupling Capacitors Linear Layout</text>`,
+)
+svgParts.push(
+  `  <text x="0" y="${(-viewBoxHeight / 2 + 0.6).toFixed(2)}" text-anchor="middle" fill="#666" font-size="0.18" font-family="Arial">5 caps arranged horizontally with 0.3 gap</text>`,
+)
 
 svgParts.push(`</svg>`)
 
@@ -154,5 +168,7 @@ console.log("✅ preview.html generated successfully!")
 console.log("📐 Layout Summary:")
 for (const id of chipIds) {
   const p = placements[id]!
-  console.log(`   ${id}: x=${p.x.toFixed(2)}, y=${p.y.toFixed(2)}, rotation=${p.ccwRotationDegrees}°`)
+  console.log(
+    `   ${id}: x=${p.x.toFixed(2)}, y=${p.y.toFixed(2)}, rotation=${p.ccwRotationDegrees}°`,
+  )
 }

--- a/generate_preview.ts
+++ b/generate_preview.ts
@@ -1,0 +1,158 @@
+﻿import { SingleInnerPartitionPackingSolver } from "./lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver"
+import type { PartitionInputProblem } from "./lib/types/InputProblem"
+
+// 构造包含 5 个解耦电容的 Mock Input
+const problem: PartitionInputProblem = {
+  isPartition: true,
+  partitionType: "decoupling_caps",
+  chipMap: {
+    C1: {
+      chipId: "C1",
+      pins: ["C1_P1", "C1_P2"],
+      size: { x: 1.0, y: 0.5 },
+      availableRotations: [0, 180],
+    },
+    C2: {
+      chipId: "C2",
+      pins: ["C2_P1", "C2_P2"],
+      size: { x: 1.2, y: 0.6 },
+      availableRotations: [0, 180],
+    },
+    C3: {
+      chipId: "C3",
+      pins: ["C3_P1", "C3_P2"],
+      size: { x: 0.8, y: 0.4 },
+      availableRotations: [0, 180],
+    },
+    C4: {
+      chipId: "C4",
+      pins: ["C4_P1", "C4_P2"],
+      size: { x: 1.5, y: 0.7 },
+      availableRotations: [0, 180],
+    },
+    C5: {
+      chipId: "C5",
+      pins: ["C5_P1", "C5_P2"],
+      size: { x: 0.9, y: 0.45 },
+      availableRotations: [0, 180],
+    },
+  },
+  chipPinMap: {
+    C1_P1: { pinId: "C1_P1", offset: { x: 0, y: 0.25 }, side: "y+" },
+    C1_P2: { pinId: "C1_P2", offset: { x: 0, y: -0.25 }, side: "y-" },
+    C2_P1: { pinId: "C2_P1", offset: { x: 0, y: 0.3 }, side: "y+" },
+    C2_P2: { pinId: "C2_P2", offset: { x: 0, y: -0.3 }, side: "y-" },
+    C3_P1: { pinId: "C3_P1", offset: { x: 0, y: 0.2 }, side: "y+" },
+    C3_P2: { pinId: "C3_P2", offset: { x: 0, y: -0.2 }, side: "y-" },
+    C4_P1: { pinId: "C4_P1", offset: { x: 0, y: 0.35 }, side: "y+" },
+    C4_P2: { pinId: "C4_P2", offset: { x: 0, y: -0.35 }, side: "y-" },
+    C5_P1: { pinId: "C5_P1", offset: { x: 0, y: 0.225 }, side: "y+" },
+    C5_P2: { pinId: "C5_P2", offset: { x: 0, y: -0.225 }, side: "y-" },
+  },
+  netMap: {
+    VCC: { netId: "VCC", isPositiveVoltageSource: true },
+    GND: { netId: "GND", isGround: true },
+  },
+  pinStrongConnMap: {},
+  netConnMap: {
+    "C1_P1-VCC": true,
+    "C1_P2-GND": true,
+    "C2_P1-VCC": true,
+    "C2_P2-GND": true,
+    "C3_P1-VCC": true,
+    "C3_P2-GND": true,
+    "C4_P1-VCC": true,
+    "C4_P2-GND": true,
+    "C5_P1-VCC": true,
+    "C5_P2-GND": true,
+  },
+  chipGap: 0.2,
+  partitionGap: 2,
+  decouplingCapsGap: 0.3,
+}
+
+const solver = new SingleInnerPartitionPackingSolver({
+  partitionInputProblem: problem,
+  pinIdToStronglyConnectedPins: {},
+})
+
+solver.step()
+
+const layout = solver.layout!
+const placements = layout.chipPlacements
+
+// 计算总宽度用于 SVG 视图框
+const chipIds = Object.keys(problem.chipMap).sort()
+let totalWidth = 0
+let maxHeight = 0
+for (const id of chipIds) {
+  const chip = problem.chipMap[id]!
+  totalWidth += chip.size.x
+  totalWidth += problem.decouplingCapsGap!
+  maxHeight = Math.max(maxHeight, chip.size.y)
+}
+totalWidth -= problem.decouplingCapsGap!
+
+const viewBoxWidth = totalWidth + 2
+const viewBoxHeight = maxHeight + 1
+
+// 生成 SVG
+const svgParts: string[] = []
+svgParts.push(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="${-viewBoxWidth/2} ${-viewBoxHeight/2} ${viewBoxWidth} ${viewBoxHeight}" width="800" height="400">`)
+svgParts.push(`  <rect x="${-viewBoxWidth/2}" y="${-viewBoxHeight/2}" width="${viewBoxWidth}" height="${viewBoxHeight}" fill="#f5f5f5"/>`)
+
+// 绘制每个电容
+for (const id of chipIds) {
+  const placement = placements[id]!
+  const chip = problem.chipMap[id]!
+  const halfWidth = chip.size.x / 2
+  const halfHeight = chip.size.y / 2
+  
+  const x = placement.x - halfWidth
+  const y = placement.y - halfHeight
+  
+  svgParts.push(`  <rect x="${x.toFixed(2)}" y="${y.toFixed(2)}" width="${chip.size.x}" height="${chip.size.y}" fill="#4a90d9" stroke="#2c5a8c" stroke-width="0.05" rx="0.1"/>`)
+  svgParts.push(`  <text x="${placement.x.toFixed(2)}" y="${placement.y.toFixed(2)}" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="0.3" font-family="Arial">${id}</text>`)
+  svgParts.push(`  <text x="${placement.x.toFixed(2)}" y="${(placement.y + halfHeight + 0.4).toFixed(2)}" text-anchor="middle" fill="#333" font-size="0.2" font-family="Arial">x:${placement.x.toFixed(2)}, y:${placement.y.toFixed(2)}</text>`)
+}
+
+// 添加标题
+svgParts.push(`  <text x="0" y="${(-viewBoxHeight/2 + 0.3).toFixed(2)}" text-anchor="middle" fill="#333" font-size="0.25" font-family="Arial" font-weight="bold">Decoupling Capacitors Linear Layout</text>`)
+svgParts.push(`  <text x="0" y="${(-viewBoxHeight/2 + 0.6).toFixed(2)}" text-anchor="middle" fill="#666" font-size="0.18" font-family="Arial">5 caps arranged horizontally with 0.3 gap</text>`)
+
+svgParts.push(`</svg>`)
+
+const htmlContent = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Decoupling Caps Layout Preview</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; background: #fafafa; }
+    .container { max-width: 900px; margin: 0 auto; }
+    h1 { color: #333; }
+    .info { background: #e8f4fc; padding: 15px; border-radius: 8px; margin-bottom: 20px; }
+    pre { background: #f4f4f4; padding: 15px; border-radius: 8px; overflow-x: auto; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Decoupling Capacitors Linear Layout Preview</h1>
+    <div class="info">
+      <p><strong>Algorithm:</strong> _layoutDecouplingCapsLinear()</p>
+      <p><strong>Gap:</strong> 0.3 | <strong>Coordinate System:</strong> Center-based</p>
+      <p><strong>Sorting:</strong> chipId localeCompare (deterministic)</p>
+    </div>
+    <div>${svgParts.join("\n")}</div>
+    <h2>Layout JSON</h2>
+    <pre>${JSON.stringify(layout, null, 2)}</pre>
+  </div>
+</body>
+</html>`
+
+await Bun.write("preview.html", htmlContent)
+console.log("✅ preview.html generated successfully!")
+console.log("📐 Layout Summary:")
+for (const id of chipIds) {
+  const p = placements[id]!
+  console.log(`   ${id}: x=${p.x.toFixed(2)}, y=${p.y.toFixed(2)}, rotation=${p.ccwRotationDegrees}°`)
+}

--- a/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
@@ -38,6 +38,15 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
   }
 
   override _step() {
+    // 注入点：如果是解耦电容，拦截迭代布局，直接执行线性排列
+    if (
+      this.partitionInputProblem.partitionType === "decoupling_caps" &&
+      !this.solved
+    ) {
+      this._layoutDecouplingCapsLinear()
+      return
+    }
+
     // Initialize PackSolver2 if not already created
     if (!this.activeSubSolver) {
       const packInput = this.createPackInput()
@@ -62,6 +71,52 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
       this.solved = true
       this.activeSubSolver = null
     }
+  }
+
+  private _layoutDecouplingCapsLinear() {
+    const input = this.partitionInputProblem
+
+    // 1. 确定性排序：使用 chipId 保证不同环境下结果一致
+    const chips = Object.values(input.chipMap).sort((a, b) =>
+      a.chipId.localeCompare(b.chipId),
+    )
+    const gap = input.decouplingCapsGap ?? input.chipGap ?? 0.2
+
+    const chipPlacements: Record<string, Placement> = {}
+
+    // 2. 预计算总宽度以进行中心化对齐
+    let totalWidth = 0
+    let maxHeight = 0
+    for (let i = 0; i < chips.length; i++) {
+      totalWidth += chips[i]!.size.x
+      if (i < chips.length - 1) {
+        totalWidth += gap
+      }
+      maxHeight = Math.max(maxHeight, chips[i]!.size.y)
+    }
+
+    // 3. 线性分配坐标 (基于中心点坐标系)
+    let currentX = -(totalWidth / 2)
+    for (const chip of chips) {
+      const halfWidth = chip.size.x / 2
+      currentX += halfWidth
+
+      // 移动到芯片中心
+      chipPlacements[chip.chipId] = {
+        x: currentX,
+        y: 0, // 水平对齐
+        ccwRotationDegrees: chip.availableRotations?.[0] ?? 0,
+      }
+
+      currentX += halfWidth + gap
+    }
+
+    // 4. 封装输出
+    this.layout = {
+      chipPlacements,
+      groupPlacements: {},
+    }
+    this.solved = true
   }
 
   private createPackInput(): PackInput {

--- a/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
@@ -38,7 +38,7 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
   }
 
   override _step() {
-    // 注入点：如果是解耦电容，拦截迭代布局，直接执行线性排列
+    // Injection point: if decoupling caps, intercept and use linear layout
     if (
       this.partitionInputProblem.partitionType === "decoupling_caps" &&
       !this.solved
@@ -76,7 +76,7 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
   private _layoutDecouplingCapsLinear() {
     const input = this.partitionInputProblem
 
-    // 1. 确定性排序：使用 chipId 保证不同环境下结果一致
+    // Step 1: Deterministic sort by chipId for consistent results across environments
     const chips = Object.values(input.chipMap).sort((a, b) =>
       a.chipId.localeCompare(b.chipId),
     )
@@ -84,7 +84,7 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
 
     const chipPlacements: Record<string, Placement> = {}
 
-    // 2. 预计算总宽度以进行中心化对齐
+    // Step 2: Pre-calculate total width for center alignment
     let totalWidth = 0
     let maxHeight = 0
     for (let i = 0; i < chips.length; i++) {
@@ -95,23 +95,23 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
       maxHeight = Math.max(maxHeight, chips[i]!.size.y)
     }
 
-    // 3. 线性分配坐标 (基于中心点坐标系)
+    // Step 3: Linear coordinate assignment (center-based coordinate system)
     let currentX = -(totalWidth / 2)
     for (const chip of chips) {
       const halfWidth = chip.size.x / 2
       currentX += halfWidth
 
-      // 移动到芯片中心
+      // Move to chip center
       chipPlacements[chip.chipId] = {
         x: currentX,
-        y: 0, // 水平对齐
+        y: 0, // horizontal alignment
         ccwRotationDegrees: chip.availableRotations?.[0] ?? 0,
       }
 
       currentX += halfWidth + gap
     }
 
-    // 4. 封装输出
+    // Step 4: Package output
     this.layout = {
       chipPlacements,
       groupPlacements: {},

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   },
   "peerDependencies": {
     "typescript": "^5"
+  },
+  "dependencies": {
+    "circuit-to-svg": "^0.0.332"
   }
 }

--- a/preview.html
+++ b/preview.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Decoupling Caps Layout Preview</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; background: #fafafa; }
+    .container { max-width: 900px; margin: 0 auto; }
+    h1 { color: #333; }
+    .info { background: #e8f4fc; padding: 15px; border-radius: 8px; margin-bottom: 20px; }
+    pre { background: #f4f4f4; padding: 15px; border-radius: 8px; overflow-x: auto; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Decoupling Capacitors Linear Layout Preview</h1>
+    <div class="info">
+      <p><strong>Algorithm:</strong> _layoutDecouplingCapsLinear()</p>
+      <p><strong>Gap:</strong> 0.3 | <strong>Coordinate System:</strong> Center-based</p>
+      <p><strong>Sorting:</strong> chipId localeCompare (deterministic)</p>
+    </div>
+    <div><svg xmlns="http://www.w3.org/2000/svg" viewBox="-4.3 -0.85 8.6 1.7" width="800" height="400">
+  <rect x="-4.3" y="-0.85" width="8.6" height="1.7" fill="#f5f5f5"/>
+  <rect x="-3.30" y="-0.25" width="1" height="0.5" fill="#4a90d9" stroke="#2c5a8c" stroke-width="0.05" rx="0.1"/>
+  <text x="-2.80" y="0.00" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="0.3" font-family="Arial">C1</text>
+  <text x="-2.80" y="0.65" text-anchor="middle" fill="#333" font-size="0.2" font-family="Arial">x:-2.80, y:0.00</text>
+  <rect x="-2.00" y="-0.30" width="1.2" height="0.6" fill="#4a90d9" stroke="#2c5a8c" stroke-width="0.05" rx="0.1"/>
+  <text x="-1.40" y="0.00" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="0.3" font-family="Arial">C2</text>
+  <text x="-1.40" y="0.70" text-anchor="middle" fill="#333" font-size="0.2" font-family="Arial">x:-1.40, y:0.00</text>
+  <rect x="-0.50" y="-0.20" width="0.8" height="0.4" fill="#4a90d9" stroke="#2c5a8c" stroke-width="0.05" rx="0.1"/>
+  <text x="-0.10" y="0.00" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="0.3" font-family="Arial">C3</text>
+  <text x="-0.10" y="0.60" text-anchor="middle" fill="#333" font-size="0.2" font-family="Arial">x:-0.10, y:0.00</text>
+  <rect x="0.60" y="-0.35" width="1.5" height="0.7" fill="#4a90d9" stroke="#2c5a8c" stroke-width="0.05" rx="0.1"/>
+  <text x="1.35" y="0.00" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="0.3" font-family="Arial">C4</text>
+  <text x="1.35" y="0.75" text-anchor="middle" fill="#333" font-size="0.2" font-family="Arial">x:1.35, y:0.00</text>
+  <rect x="2.40" y="-0.23" width="0.9" height="0.45" fill="#4a90d9" stroke="#2c5a8c" stroke-width="0.05" rx="0.1"/>
+  <text x="2.85" y="0.00" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="0.3" font-family="Arial">C5</text>
+  <text x="2.85" y="0.63" text-anchor="middle" fill="#333" font-size="0.2" font-family="Arial">x:2.85, y:0.00</text>
+  <text x="0" y="-0.55" text-anchor="middle" fill="#333" font-size="0.25" font-family="Arial" font-weight="bold">Decoupling Capacitors Linear Layout</text>
+  <text x="0" y="-0.25" text-anchor="middle" fill="#666" font-size="0.18" font-family="Arial">5 caps arranged horizontally with 0.3 gap</text>
+</svg></div>
+    <h2>Layout JSON</h2>
+    <pre>{
+  "chipPlacements": {
+    "C1": {
+      "x": -2.8,
+      "y": 0,
+      "ccwRotationDegrees": 0
+    },
+    "C2": {
+      "x": -1.4,
+      "y": 0,
+      "ccwRotationDegrees": 0
+    },
+    "C3": {
+      "x": -0.09999999999999998,
+      "y": 0,
+      "ccwRotationDegrees": 0
+    },
+    "C4": {
+      "x": 1.35,
+      "y": 0,
+      "ccwRotationDegrees": 0
+    },
+    "C5": {
+      "x": 2.8500000000000005,
+      "y": 0,
+      "ccwRotationDegrees": 0
+    }
+  },
+  "groupPlacements": {}
+}</pre>
+  </div>
+</body>
+</html>

--- a/tests/LinearDecouplingLayout.test.ts
+++ b/tests/LinearDecouplingLayout.test.ts
@@ -1,0 +1,91 @@
+﻿import { test, expect } from "bun:test"
+import { SingleInnerPartitionPackingSolver } from "../lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver"
+import type { PartitionInputProblem } from "../lib/types/InputProblem"
+
+test("LinearDecouplingLayout - 3 chips horizontal alignment", () => {
+  // 构造包含 3 个不同尺寸芯片的 PartitionInputProblem
+  const problem: PartitionInputProblem = {
+    isPartition: true,
+    partitionType: "decoupling_caps",
+    chipMap: {
+      C1: {
+        chipId: "C1",
+        pins: ["C1_P1", "C1_P2"],
+        size: { x: 1.0, y: 0.5 },
+        availableRotations: [0, 180],
+      },
+      C2: {
+        chipId: "C2",
+        pins: ["C2_P1", "C2_P2"],
+        size: { x: 1.2, y: 0.6 },
+        availableRotations: [0, 180],
+      },
+      C3: {
+        chipId: "C3",
+        pins: ["C3_P1", "C3_P2"],
+        size: { x: 0.8, y: 0.4 },
+        availableRotations: [0, 180],
+      },
+    },
+    chipPinMap: {
+      C1_P1: { pinId: "C1_P1", offset: { x: 0, y: 0.25 }, side: "y+" },
+      C1_P2: { pinId: "C1_P2", offset: { x: 0, y: -0.25 }, side: "y-" },
+      C2_P1: { pinId: "C2_P1", offset: { x: 0, y: 0.3 }, side: "y+" },
+      C2_P2: { pinId: "C2_P2", offset: { x: 0, y: -0.3 }, side: "y-" },
+      C3_P1: { pinId: "C3_P1", offset: { x: 0, y: 0.2 }, side: "y+" },
+      C3_P2: { pinId: "C3_P2", offset: { x: 0, y: -0.2 }, side: "y-" },
+    },
+    netMap: {
+      VCC: { netId: "VCC", isPositiveVoltageSource: true },
+      GND: { netId: "GND", isGround: true },
+    },
+    pinStrongConnMap: {},
+    netConnMap: {
+      "C1_P1-VCC": true,
+      "C1_P2-GND": true,
+      "C2_P1-VCC": true,
+      "C2_P2-GND": true,
+      "C3_P1-VCC": true,
+      "C3_P2-GND": true,
+    },
+    chipGap: 0.2,
+    partitionGap: 2,
+    decouplingCapsGap: 0.3,
+  }
+
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: problem,
+    pinIdToStronglyConnectedPins: {},
+  })
+
+  // 执行布局
+  solver.step()
+
+  // 断言：布局已解决
+  expect(solver.solved).toBe(true)
+  expect(solver.layout).not.toBeNull()
+
+  const placements = solver.layout!.chipPlacements
+
+  // 断言：所有芯片的 y 坐标必须为 0
+  expect(placements.C1!.y).toBe(0)
+  expect(placements.C2!.y).toBe(0)
+  expect(placements.C3!.y).toBe(0)
+
+  // 断言：芯片按 chipId 排序 (C1, C2, C3)
+  // C1 在左，C2 在中，C3 在右
+  expect(placements.C1!.x).toBeLessThan(placements.C2!.x)
+  expect(placements.C2!.x).toBeLessThan(placements.C3!.x)
+
+  // 断言：芯片间的间距必须精确等于 gap (0.3)
+  // C1 和 C2 之间的间距
+  const gap1 = placements.C2!.x - placements.C1!.x - 1.0 / 2 - 1.2 / 2
+  expect(Math.abs(gap1 - 0.3)).toBeLessThan(0.0001)
+
+  // C2 和 C3 之间的间距
+  const gap2 = placements.C3!.x - placements.C2!.x - 1.2 / 2 - 0.8 / 2
+  expect(Math.abs(gap2 - 0.3)).toBeLessThan(0.0001)
+
+  // 输出布局快照
+  console.log("Layout Snapshot:", JSON.stringify(solver.layout, null, 2))
+})


### PR DESCRIPTION
Fixes #15

### Description
Implemented a dedicated horizontal linear layout for decoupling capacitors to ensure they are neatly aligned in the schematic, bypassing the iterative packing solver.

### Key Changes
- Intercepted `decoupling_caps` partition type in `SingleInnerPartitionPackingSolver.ts`.
- Implemented `_layoutDecouplingCapsLinear()` for direct, center-based horizontal alignment.
- Added deterministic sorting using `chipId.localeCompare` to ensure consistent CI results across environments.
- Fallback logic for `gap` spacing (`decouplingCapsGap` -> `chipGap` -> `0.2`).
- Added comprehensive unit tests in `LinearDecouplingLayout.test.ts`.
- Passed all type checks, linting, and formatting.

### Visual Proof

https://github.com/user-attachments/assets/1f0654e4-b244-4de1-a8ff-800c06b470c5