### PR TITLE
feat: add overlap resolution phase after partition packing

### DIFF
--- a/lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver.ts
+++ b/lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver.ts
@@ -7,16 +7,17 @@ import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver"
 import { ChipPartitionsSolver } from "lib/solvers/ChipPartitionsSolver/ChipPartitionsSolver"
 import { IdentifyDecouplingCapsSolver } from "lib/solvers/IdentifyDecouplingCapsSolver/IdentifyDecouplingCapsSolver"
+import { OverlapResolutionSolver } from "lib/solvers/OverlapResolutionSolver/OverlapResolutionSolver"
 import {
-  PackInnerPartitionsSolver,
   type PackedPartition,
+  PackInnerPartitionsSolver,
 } from "lib/solvers/PackInnerPartitionsSolver/PackInnerPartitionsSolver"
 import { PartitionPackingSolver } from "lib/solvers/PartitionPackingSolver/PartitionPackingSolver"
 import type { ChipPin, InputProblem, PinId } from "lib/types/InputProblem"
 import type { OutputLayout } from "lib/types/OutputLayout"
 import { doBasicInputProblemLayout } from "./doBasicInputProblemLayout"
-import { visualizeInputProblem } from "./visualizeInputProblem"
 import { getPinIdToStronglyConnectedPinsObj } from "./getPinIdToStronglyConnectedPinsObj"
+import { visualizeInputProblem } from "./visualizeInputProblem"
 
 type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   solverName: string
@@ -53,6 +54,7 @@ export class LayoutPipelineSolver extends BaseSolver {
   chipPartitionsSolver?: ChipPartitionsSolver
   packInnerPartitionsSolver?: PackInnerPartitionsSolver
   partitionPackingSolver?: PartitionPackingSolver
+  overlapResolutionSolver?: OverlapResolutionSolver
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -124,6 +126,16 @@ export class LayoutPipelineSolver extends BaseSolver {
         },
       },
     ),
+    definePipelineStep(
+      "overlapResolutionSolver",
+      OverlapResolutionSolver,
+      () => [
+        {
+          inputProblem: this.inputProblem,
+          initialLayout: this.partitionPackingSolver!.finalLayout!,
+        },
+      ],
+    ),
   ]
 
   constructor(inputProblem: InputProblem) {
@@ -166,7 +178,7 @@ export class LayoutPipelineSolver extends BaseSolver {
     }
 
     const constructorParams = pipelineStepDef.getConstructorParams(this)
-    // @ts-ignore
+    // @ts-expect-error
     this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
     ;(this as any)[pipelineStepDef.solverName] = this.activeSubSolver
     this.timeSpentOnPhase[pipelineStepDef.solverName] = 0
@@ -190,6 +202,9 @@ export class LayoutPipelineSolver extends BaseSolver {
 
     // If the pipeline is complete and we have a partition packing solver,
     // show only the final chip placements
+    if (this.solved && this.overlapResolutionSolver?.solved) {
+      return this.overlapResolutionSolver.visualize()
+    }
     if (this.solved && this.partitionPackingSolver?.solved) {
       return this.partitionPackingSolver.visualize()
     }
@@ -199,6 +214,7 @@ export class LayoutPipelineSolver extends BaseSolver {
     const chipPartitionsViz = this.chipPartitionsSolver?.visualize()
     const packInnerPartitionsViz = this.packInnerPartitionsSolver?.visualize()
     const partitionPackingViz = this.partitionPackingSolver?.visualize()
+    const overlapResolutionViz = this.overlapResolutionSolver?.visualize()
 
     // Get basic layout positions to avoid overlapping at (0,0)
     const basicLayout = doBasicInputProblemLayout(this.inputProblem)
@@ -210,6 +226,7 @@ export class LayoutPipelineSolver extends BaseSolver {
       chipPartitionsViz,
       packInnerPartitionsViz,
       partitionPackingViz,
+      overlapResolutionViz,
     ]
       .filter(Boolean)
       .map((viz, stepIndex) => {
@@ -253,6 +270,9 @@ export class LayoutPipelineSolver extends BaseSolver {
     }
 
     // Show the most recent solver's output
+    if (this.overlapResolutionSolver?.solved) {
+      return this.overlapResolutionSolver.visualize()
+    }
     if (this.partitionPackingSolver?.solved) {
       return this.partitionPackingSolver.visualize()
     }
@@ -402,6 +422,11 @@ export class LayoutPipelineSolver extends BaseSolver {
 
     // Get the final layout from the partition packing solver
     if (
+      this.overlapResolutionSolver?.solved &&
+      this.overlapResolutionSolver.resolvedLayout
+    ) {
+      finalLayout = this.overlapResolutionSolver.resolvedLayout
+    } else if (
       this.partitionPackingSolver?.solved &&
       this.partitionPackingSolver.finalLayout
     ) {

--- a/lib/solvers/OverlapResolutionSolver/OverlapResolutionSolver.ts
+++ b/lib/solvers/OverlapResolutionSolver/OverlapResolutionSolver.ts
@@ -1,0 +1,173 @@
+import type { GraphicsObject } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver"
+import { visualizeInputProblem } from "lib/solvers/LayoutPipelineSolver/visualizeInputProblem"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { OutputLayout } from "lib/types/OutputLayout"
+
+export interface OverlapResolutionSolverInput {
+  inputProblem: InputProblem
+  initialLayout: OutputLayout
+  maxIterations?: number
+}
+
+type Bounds = {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+}
+
+export class OverlapResolutionSolver extends BaseSolver {
+  inputProblem: InputProblem
+  resolvedLayout: OutputLayout
+  maxIterations: number
+
+  constructor(input: OverlapResolutionSolverInput) {
+    super()
+    this.inputProblem = input.inputProblem
+    this.resolvedLayout = {
+      chipPlacements: Object.fromEntries(
+        Object.entries(input.initialLayout.chipPlacements).map(
+          ([chipId, placement]) => [chipId, { ...placement }],
+        ),
+      ),
+      groupPlacements: { ...input.initialLayout.groupPlacements },
+    }
+    this.maxIterations = input.maxIterations ?? 150
+    this.MAX_ITERATIONS = this.maxIterations
+  }
+
+  override _step() {
+    const chipIds = Object.keys(this.resolvedLayout.chipPlacements)
+    if (chipIds.length <= 1) {
+      this.solved = true
+      return
+    }
+
+    const displacement: Record<string, { x: number; y: number }> = {}
+    for (const chipId of chipIds) {
+      displacement[chipId] = { x: 0, y: 0 }
+    }
+
+    let overlapsFound = 0
+    const minGap = Math.max(this.inputProblem.chipGap ?? 0, 0)
+    const epsilon = 1e-6
+
+    for (let i = 0; i < chipIds.length; i++) {
+      for (let j = i + 1; j < chipIds.length; j++) {
+        const chipA = chipIds[i]!
+        const chipB = chipIds[j]!
+        const boundsA = this.getChipBounds(chipA, minGap / 2)
+        const boundsB = this.getChipBounds(chipB, minGap / 2)
+
+        const overlapX =
+          Math.min(boundsA.maxX, boundsB.maxX) -
+          Math.max(boundsA.minX, boundsB.minX)
+        const overlapY =
+          Math.min(boundsA.maxY, boundsB.maxY) -
+          Math.max(boundsA.minY, boundsB.minY)
+
+        if (overlapX <= 0 || overlapY <= 0) {
+          continue
+        }
+
+        overlapsFound++
+        const placementA = this.resolvedLayout.chipPlacements[chipA]!
+        const placementB = this.resolvedLayout.chipPlacements[chipB]!
+
+        if (overlapX < overlapY) {
+          const direction =
+            placementA.x === placementB.x
+              ? chipA < chipB
+                ? -1
+                : 1
+              : placementA.x < placementB.x
+                ? -1
+                : 1
+          const push = (overlapX + epsilon) / 2
+          displacement[chipA]!.x += direction * push
+          displacement[chipB]!.x -= direction * push
+        } else {
+          const direction =
+            placementA.y === placementB.y
+              ? chipA < chipB
+                ? -1
+                : 1
+              : placementA.y < placementB.y
+                ? -1
+                : 1
+          const push = (overlapY + epsilon) / 2
+          displacement[chipA]!.y += direction * push
+          displacement[chipB]!.y -= direction * push
+        }
+      }
+    }
+
+    let maxMovement = 0
+    const damping = 0.85
+    for (const chipId of chipIds) {
+      const delta = displacement[chipId]!
+      const stepX = delta.x * damping
+      const stepY = delta.y * damping
+      const placement = this.resolvedLayout.chipPlacements[chipId]!
+      placement.x += stepX
+      placement.y += stepY
+      maxMovement = Math.max(maxMovement, Math.hypot(stepX, stepY))
+    }
+
+    if (overlapsFound === 0 || maxMovement < 1e-6) {
+      this.recenterLayout()
+      this.solved = true
+    }
+  }
+
+  private getChipBounds(chipId: string, inflation = 0): Bounds {
+    const placement = this.resolvedLayout.chipPlacements[chipId]!
+    const chip = this.inputProblem.chipMap[chipId]!
+    const rotation = ((placement.ccwRotationDegrees % 360) + 360) % 360
+    const isVertical = rotation === 90 || rotation === 270
+    const width = isVertical ? chip.size.y : chip.size.x
+    const height = isVertical ? chip.size.x : chip.size.y
+    const halfWidth = width / 2 + inflation
+    const halfHeight = height / 2 + inflation
+
+    return {
+      minX: placement.x - halfWidth,
+      maxX: placement.x + halfWidth,
+      minY: placement.y - halfHeight,
+      maxY: placement.y + halfHeight,
+    }
+  }
+
+  private recenterLayout() {
+    const placements = Object.values(this.resolvedLayout.chipPlacements)
+    if (placements.length === 0) return
+    const centerX =
+      placements.reduce((sum, placement) => sum + placement.x, 0) /
+      placements.length
+    const centerY =
+      placements.reduce((sum, placement) => sum + placement.y, 0) /
+      placements.length
+
+    for (const placement of placements) {
+      placement.x -= centerX
+      placement.y -= centerY
+    }
+  }
+
+  override getConstructorParams(): OverlapResolutionSolverInput {
+    return {
+      inputProblem: this.inputProblem,
+      initialLayout: this.resolvedLayout,
+      maxIterations: this.maxIterations,
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    return visualizeInputProblem(this.inputProblem, this.resolvedLayout)
+  }
+
+  override preview(): GraphicsObject {
+    return this.visualize()
+  }
+}

--- a/tests/OverlapResolutionSolver/overlap-resolution-solver.test.ts
+++ b/tests/OverlapResolutionSolver/overlap-resolution-solver.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "bun:test"
+import { LayoutPipelineSolver } from "lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver"
+import { OverlapResolutionSolver } from "lib/solvers/OverlapResolutionSolver/OverlapResolutionSolver"
+import { getInputProblemFromCircuitJsonSchematic } from "lib/testing/getInputProblemFromCircuitJsonSchematic"
+import type { InputProblem } from "lib/types/InputProblem"
+import type { OutputLayout } from "lib/types/OutputLayout"
+import { getExampleCircuitJson } from "../assets/ExampleCircuit04"
+
+const getChipBounds = (
+  layout: OutputLayout,
+  inputProblem: InputProblem,
+  chipId: string,
+) => {
+  const placement = layout.chipPlacements[chipId]!
+  const chip = inputProblem.chipMap[chipId]!
+  return {
+    minX: placement.x - chip.size.x / 2,
+    maxX: placement.x + chip.size.x / 2,
+    minY: placement.y - chip.size.y / 2,
+    maxY: placement.y + chip.size.y / 2,
+  }
+}
+
+const hasOverlap = (
+  layout: OutputLayout,
+  inputProblem: InputProblem,
+  chipA: string,
+  chipB: string,
+) => {
+  const a = getChipBounds(layout, inputProblem, chipA)
+  const b = getChipBounds(layout, inputProblem, chipB)
+  return !(
+    a.maxX <= b.minX ||
+    a.minX >= b.maxX ||
+    a.maxY <= b.minY ||
+    a.minY >= b.maxY
+  )
+}
+
+test("OverlapResolutionSolver separates overlapping chips", () => {
+  const inputProblem: InputProblem = {
+    chipMap: {
+      U1: { chipId: "U1", pins: [], size: { x: 2, y: 2 } },
+      U2: { chipId: "U2", pins: [], size: { x: 2, y: 2 } },
+    },
+    chipPinMap: {},
+    netMap: {},
+    pinStrongConnMap: {},
+    netConnMap: {},
+    chipGap: 0.2,
+    partitionGap: 0.5,
+  }
+
+  const initialLayout: OutputLayout = {
+    chipPlacements: {
+      U1: { x: 0, y: 0, ccwRotationDegrees: 0 },
+      U2: { x: 0.5, y: 0, ccwRotationDegrees: 0 },
+    },
+    groupPlacements: {},
+  }
+
+  expect(hasOverlap(initialLayout, inputProblem, "U1", "U2")).toBe(true)
+
+  const solver = new OverlapResolutionSolver({
+    inputProblem,
+    initialLayout,
+  })
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.resolvedLayout).toBeDefined()
+  expect(hasOverlap(solver.resolvedLayout!, inputProblem, "U1", "U2")).toBe(
+    false,
+  )
+})
+
+test("LayoutPipelineSolver includes overlap resolution as final phase", () => {
+  const circuitJson = getExampleCircuitJson()
+  const inputProblem = getInputProblemFromCircuitJsonSchematic(circuitJson, {
+    useReadableIds: true,
+  })
+
+  const solver = new LayoutPipelineSolver(inputProblem)
+  const phaseNames = solver.pipelineDef.map((step) => step.solverName)
+
+  expect(phaseNames.at(-1)).toBe("overlapResolutionSolver")
+
+  solver.solve()
+  expect(solver.overlapResolutionSolver?.solved).toBe(true)
+})


### PR DESCRIPTION
## Summary
- add `OverlapResolutionSolver` as a final layout phase after `PartitionPackingSolver`
- resolve residual chip overlaps with deterministic pairwise displacement and chip-gap-aware bounds
- return overlap-resolved placement in `getOutputLayout()`
- include dedicated tests for solver behavior and pipeline integration

## Why
Issue #12 asks for improved layout quality for the repro in #11 and suggests a new phase/technique. This adds a focused post-pack cleanup phase that removes residual overlaps without changing upstream partition logic.

## TDD
- RED: added failing test file for missing solver + missing final phase
- GREEN: implemented solver + integrated phase into pipeline

## Validation
```bash
bun test tests/OverlapResolutionSolver/overlap-resolution-solver.test.ts
bun test tests/LayoutPipelineSolver/LayoutPipelineSolver04.test.ts tests/PartitionPackingSolver/PartitionPackingSolver01.test.ts
bunx biome check lib/solvers/OverlapResolutionSolver/OverlapResolutionSolver.ts lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver.ts tests/OverlapResolutionSolver/overlap-resolution-solver.test.ts
```

/claim #12