### PR TITLE
test: add deterministic overlap regression coverage for issue #12

### DIFF
--- a/tests/LayoutPipelineSolver/LayoutPipelineSolver02.test.ts
+++ b/tests/LayoutPipelineSolver/LayoutPipelineSolver02.test.ts
@@ -251,6 +251,18 @@ test("LayoutPipelineSolver02 deterministic overlap-free output across repeated r
     expect(current.y).toBe(reference.y)
     expect(current.ccwRotationDegrees).toBe(reference.ccwRotationDegrees)
   }
+
+  // Secondary anchor chip consistency to reduce false confidence on single-chip checks
+  const c1Reference = results[0].chipPlacements["C1"]
+  expect(c1Reference).toBeDefined()
+
+  for (const layout of results.slice(1)) {
+    const currentC1 = layout.chipPlacements["C1"]
+    expect(currentC1).toBeDefined()
+    expect(currentC1.x).toBe(c1Reference.x)
+    expect(currentC1.y).toBe(c1Reference.y)
+    expect(currentC1.ccwRotationDegrees).toBe(c1Reference.ccwRotationDegrees)
+  }
 })
 
 test("LayoutPipelineSolver02 overlap detection functionality", () => {

--- a/tests/LayoutPipelineSolver/LayoutPipelineSolver02.test.ts
+++ b/tests/LayoutPipelineSolver/LayoutPipelineSolver02.test.ts
@@ -221,6 +221,38 @@ test("LayoutPipelineSolver02 complete pipeline execution", () => {
   expect(overlaps.length).toBe(0)
 })
 
+test("LayoutPipelineSolver02 deterministic overlap-free output across repeated runs", () => {
+  const circuitJson = getExampleCircuitJson()
+
+  const results: Array<ReturnType<LayoutPipelineSolver["getOutputLayout"]>> = []
+
+  for (let i = 0; i < 3; i++) {
+    const problem = getInputProblemFromCircuitJsonSchematic(circuitJson, {
+      useReadableIds: true,
+    })
+    const solver = new LayoutPipelineSolver(problem)
+    solver.solve()
+
+    const layout = solver.getOutputLayout()
+    const overlaps = solver.checkForOverlaps(layout)
+
+    expect(overlaps.length).toBe(0)
+    results.push(layout)
+  }
+
+  // Ensure deterministic placement for a representative chip across runs
+  const reference = results[0].chipPlacements["U1"]
+  expect(reference).toBeDefined()
+
+  for (const layout of results.slice(1)) {
+    const current = layout.chipPlacements["U1"]
+    expect(current).toBeDefined()
+    expect(current.x).toBe(reference.x)
+    expect(current.y).toBe(reference.y)
+    expect(current.ccwRotationDegrees).toBe(reference.ccwRotationDegrees)
+  }
+})
+
 test("LayoutPipelineSolver02 overlap detection functionality", () => {
   // Convert ExampleCircuit02 to InputProblem
   const circuitJson = getExampleCircuitJson()


### PR DESCRIPTION
/claim #12

## Summary
Adds focused follow-up test coverage for the issue #12 lane by asserting deterministic, overlap-free pipeline output across repeated runs of the same circuit input.

## What changed
- Added `LayoutPipelineSolver02 deterministic overlap-free output across repeated runs` test in:
  - `tests/LayoutPipelineSolver/LayoutPipelineSolver02.test.ts`
- New test:
  - runs `LayoutPipelineSolver` 3 times on the same ExampleCircuit02 input,
  - asserts zero overlaps each run,
  - asserts deterministic placement consistency for representative chip `U1`.

## Validation
- `bun test tests/LayoutPipelineSolver/LayoutPipelineSolver02.test.ts`
- Result: 5 pass, 1 skip, 0 fail

## Why this helps
This gives maintainers concrete regression protection for the issue #12 class (layout quality/determinism) without duplicating broader implementation already in-flight in #39.
