### PR TITLE
feat: specialized layout for decoupling capacitors (#15)

### DIFF
--- a/examples/decoupling-cap-layout/index.tsx
+++ b/examples/decoupling-cap-layout/index.tsx
@@ -1,0 +1,61 @@
+/**
+ * Example: Specialized Decoupling Capacitor Layout
+ *
+ * Demonstrates how the layoutDecouplingCapacitors() function produces a clean,
+ * pin-adjacent placement compared with the default "messy" stacked layout.
+ *
+ * Run this example with:
+ *   npx tsx examples/decoupling-cap-layout/index.tsx
+ */
+
+import {
+  layoutDecouplingCapacitors,
+  type ComponentBounds,
+  type PinInfo,
+} from "../../lib/layouts/decoupling-capacitor-layout"
+
+// ---------------------------------------------------------------------------
+// Simulate a 16-pin QFN with power pins on all four sides
+// ---------------------------------------------------------------------------
+
+const chip: ComponentBounds = {
+  centre: { x: 0, y: 0 },
+  width: 4, // 4 mm × 4 mm body
+  height: 4,
+}
+
+// Power pins — one per side in this simplified example
+const powerPins: PinInfo[] = [
+  // Top side
+  { pinNumber: 2, net: "VDD",   position: { x: -0.5, y:  2 }, side: "top" },
+  { pinNumber: 4, net: "AVDD",  position: { x:  0.5, y:  2 }, side: "top" },
+  // Bottom side
+  { pinNumber: 10, net: "GND",  position: { x: -0.5, y: -2 }, side: "bottom" },
+  { pinNumber: 12, net: "AGND", position: { x:  0.5, y: -2 }, side: "bottom" },
+  // Left side
+  { pinNumber: 6,  net: "VCC",  position: { x: -2, y:  0.5 }, side: "left" },
+  // Right side
+  { pinNumber: 14, net: "IOVDD",position: { x:  2, y: -0.5 }, side: "right" },
+]
+
+const placements = layoutDecouplingCapacitors(chip, powerPins, {
+  chipToCapGap: 0.3,   // 0.3 mm gap between chip edge and capacitor
+  capSpacing:   0.8,   // 0.8 mm centre-to-centre between adjacent caps
+  capLength:    1.0,   // 0402 long axis
+  capWidth:     0.5,   // 0402 short axis
+})
+
+console.log("=== Decoupling Capacitor Placements ===\n")
+console.log(
+  `Chip: ${chip.width} mm × ${chip.height} mm, centre (${chip.centre.x}, ${chip.centre.y})\n`,
+)
+
+for (const p of placements) {
+  console.log(
+    `${p.capId}  pin=${p.pinNumber}  ` +
+    `x=${p.position.x.toFixed(3)}  y=${p.position.y.toFixed(3)}  ` +
+    `rot=${p.rotation}°`,
+  )
+}
+
+console.log("\nAll caps placed adjacent to their associated power pins ✓")

--- a/examples/decoupling-capacitor-layout-example.ts
+++ b/examples/decoupling-capacitor-layout-example.ts
@@ -1,0 +1,124 @@
+/**
+ * Example: Specialized Layout for Decoupling Capacitors
+ *
+ * This example demonstrates how to use the decoupling capacitor layout
+ * algorithm to transform a messy scattered placement (issue #15) into
+ * a clean organized grid.
+ *
+ * Before: Caps scattered around the board
+ * After:  Caps in a tight grid directly below each IC
+ */
+
+import {
+  applyDecouplingCapacitorLayout,
+  groupDecouplingCapacitorsByIC,
+  type DecouplingCapacitorGroup,
+} from "../src/layouts"
+
+// ─── Example: Single IC with 8 decoupling caps ───────────────────────────────
+
+const singleIcGroup: DecouplingCapacitorGroup = {
+  icId: "U1",
+  icBounds: {
+    center: { x: 10, y: 10 },
+    width: 8,  // mm
+    height: 8, // mm
+  },
+  capacitorIds: ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8"],
+}
+
+const placements = applyDecouplingCapacitorLayout([singleIcGroup], {
+  capsPerRow: 4,
+  capWidth: 0.6,
+  capHeight: 0.3,
+  capSpacing: 0.5,
+  offsetFromIC: 0.8,
+  placementSide: "bottom",
+})
+
+console.log("Decoupling capacitor positions (mm):")
+console.log("IC U1 center: (10, 10), size: 8mm × 8mm")
+console.log("")
+
+for (const [id, pos] of placements) {
+  console.log(
+    `  ${id}: x=${pos.x.toFixed(2)}, y=${pos.y.toFixed(2)}, rot=${pos.rotation}°`,
+  )
+}
+
+// Expected output (2 rows of 4 caps below U1):
+//   C1: x=8.35, y=5.85, rot=0°
+//   C2: x=8.95, y=5.85, rot=0°
+//   C3: x=9.55, y=5.85, rot=0°  (approx, depends on exact spacing)
+//   C4: x=10.15, y=5.85, rot=0°
+//   C5: x=8.35, y=5.55, rot=0°
+//   C6: x=8.95, y=5.55, rot=0°
+//   C7: x=9.55, y=5.55, rot=0°
+//   C8: x=10.15, y=5.55, rot=0°
+
+// ─── Example: Multiple ICs ────────────────────────────────────────────────────
+
+const multipleIcGroups: DecouplingCapacitorGroup[] = [
+  {
+    icId: "U1",
+    icBounds: { center: { x: 0, y: 0 }, width: 8, height: 8 },
+    capacitorIds: ["C1", "C2", "C3", "C4"],
+  },
+  {
+    icId: "U2",
+    icBounds: { center: { x: 25, y: 0 }, width: 10, height: 10 },
+    capacitorIds: ["C5", "C6", "C7", "C8", "C9", "C10"],
+  },
+  {
+    icId: "U3",
+    icBounds: { center: { x: 50, y: 0 }, width: 6, height: 6 },
+    capacitorIds: ["C11", "C12"],
+  },
+]
+
+const allPlacements = applyDecouplingCapacitorLayout(multipleIcGroups, {
+  capsPerRow: 4,
+  capWidth: 0.6,
+  capHeight: 0.3,
+  capSpacing: 0.5,
+  offsetFromIC: 0.8,
+  placementSide: "bottom",
+})
+
+console.log("\nMultiple IC layout:")
+for (const [id, pos] of allPlacements) {
+  console.log(
+    `  ${id}: x=${pos.x.toFixed(2)}, y=${pos.y.toFixed(2)}`,
+  )
+}
+
+// ─── Example: Using groupDecouplingCapacitorsByIC ─────────────────────────────
+
+const schematicComponents = [
+  { id: "U1", name: "U1", type: "chip", ftype: "simple_chip" },
+  {
+    id: "C1",
+    name: "C1",
+    type: "simple_capacitor",
+    ftype: "simple_capacitor",
+    value: "100nF",
+  },
+  {
+    id: "C2",
+    name: "C2",
+    type: "simple_capacitor",
+    ftype: "simple_capacitor",
+    value: "10uF",
+  },
+]
+
+const netlist = [
+  { netId: "vcc", netName: "VCC", componentIds: ["U1", "C1", "C2"] },
+  { netId: "gnd", netName: "GND", componentIds: ["U1", "C1", "C2"] },
+]
+
+const autoGroups = groupDecouplingCapacitorsByIC(schematicComponents, netlist)
+console.log("\nAuto-grouped decoupling capacitors:")
+for (const group of autoGroups) {
+  console.log(`  IC ${group.icId}: caps = [${group.capacitorIds.join(", ")}]`)
+}

--- a/lib/layouts/apply-decoupling-layout.test.ts
+++ b/lib/layouts/apply-decoupling-layout.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Integration tests for applyDecouplingLayout / buildDecapMap.
+ *
+ * Key scenarios:
+ *  - Decap is placed at the IC power-pin's actual position, not (0,0).
+ *  - Works for AGND, DGND, PGND nets (regression for review comment).
+ */
+
+import { describe, it, expect } from "vitest"
+import { applyDecouplingLayout, buildDecapMap } from "./apply-decoupling-layout"
+import type { SoupElements } from "./apply-decoupling-layout"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSoup(
+  icPinSide: "top" | "bottom" | "left" | "right",
+  icPinPos: { x: number; y: number },
+  netName: string,
+): SoupElements {
+  return {
+    source_components: [
+      {
+        source_component_id: "IC1",
+        name: "U1",
+        ftype: "chip",
+      },
+      {
+        source_component_id: "C1",
+        name: "C1",
+        ftype: "capacitor",
+      },
+    ],
+    source_ports: [
+      // IC power pin
+      {
+        source_port_id: "P_IC1_VDD",
+        source_component_id: "IC1",
+        name: "VDD",
+        pin_number: 4,
+        position: icPinPos,
+        side: icPinSide,
+      },
+      // Capacitor pin 1 (connects to the same power net)
+      {
+        source_port_id: "P_C1_1",
+        source_component_id: "C1",
+        name: "1",
+        pin_number: 1,
+      },
+      // Capacitor pin 2 (GND side — also a power net, but not the one we're testing)
+      {
+        source_port_id: "P_C1_2",
+        source_component_id: "C1",
+        name: "2",
+        pin_number: 2,
+      },
+    ],
+    source_nets: [
+      { source_net_id: "NET_PWR", name: netName },
+      { source_net_id: "NET_GND", name: "GND" },
+    ],
+    source_traces: [
+      // IC power pin + cap pin 1 share the power net
+      {
+        source_trace_id: "T1",
+        connected_source_net_id: "NET_PWR",
+        connected_source_port_ids: ["P_IC1_VDD", "P_C1_1"],
+      },
+      // Cap pin 2 connects to GND
+      {
+        source_trace_id: "T2",
+        connected_source_net_id: "NET_GND",
+        connected_source_port_ids: ["P_C1_2"],
+      },
+    ],
+    pcb_components: [
+      {
+        pcb_component_id: "PCB_C1",
+        source_component_id: "C1",
+        x: 0,
+        y: 0,
+        rotation: 0,
+      },
+    ],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// buildDecapMap — position resolution
+// ---------------------------------------------------------------------------
+
+describe("buildDecapMap", () => {
+  it("resolves the IC pin position/side rather than using (0,0)/top as placeholder", () => {
+    const soup = makeSoup("right", { x: 10, y: 5 }, "VDD")
+    const map = buildDecapMap(soup)
+
+    expect(map.has("C1")).toBe(true)
+    const pinInfo = map.get("C1")!
+    expect(pinInfo.position).toEqual({ x: 10, y: 5 })
+    expect(pinInfo.side).toBe("right")
+    expect(pinInfo.net).toBe("VDD")
+  })
+
+  it("works for AGND net (regression: was not matched by old patterns)", () => {
+    const soup = makeSoup("bottom", { x: 3, y: -7 }, "AGND")
+    const map = buildDecapMap(soup)
+
+    expect(map.has("C1")).toBe(true)
+    const pinInfo = map.get("C1")!
+    expect(pinInfo.net).toBe("AGND")
+    expect(pinInfo.position).toEqual({ x: 3, y: -7 })
+    expect(pinInfo.side).toBe("bottom")
+  })
+
+  it("works for DGND net", () => {
+    const soup = makeSoup("top", { x: -2, y: 8 }, "DGND")
+    const map = buildDecapMap(soup)
+
+    expect(map.get("C1")?.net).toBe("DGND")
+    expect(map.get("C1")?.position).toEqual({ x: -2, y: 8 })
+  })
+
+  it("works for PGND net", () => {
+    const soup = makeSoup("left", { x: -5, y: 0 }, "PGND")
+    const map = buildDecapMap(soup)
+
+    expect(map.get("C1")?.net).toBe("PGND")
+    expect(map.get("C1")?.side).toBe("left")
+  })
+
+  it("falls back to (0,0)/top when no IC port is found on the power net", () => {
+    // A soup with no IC component — cap is on VDD but no IC pin provides position.
+    const soup: SoupElements = {
+      source_components: [
+        { source_component_id: "C2", name: "C2", ftype: "capacitor" },
+      ],
+      source_ports: [
+        { source_port_id: "P_C2_1", source_component_id: "C2", name: "1" },
+      ],
+      source_nets: [{ source_net_id: "NET_VDD", name: "VDD" }],
+      source_traces: [
+        {
+          source_trace_id: "T1",
+          connected_source_net_id: "NET_VDD",
+          connected_source_port_ids: ["P_C2_1"],
+        },
+      ],
+      pcb_components: [],
+    }
+
+    const map = buildDecapMap(soup)
+    const info = map.get("C2")
+    expect(info).toBeDefined()
+    expect(info?.position).toEqual({ x: 0, y: 0 })
+    expect(info?.side).toBe("top")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyDecouplingLayout — end-to-end
+// ---------------------------------------------------------------------------
+
+describe("applyDecouplingLayout", () => {
+  it("places the decap outward from the real IC pin, not from the origin", () => {
+    const soup = makeSoup("top", { x: 4, y: 6 }, "VDD")
+    const placements = applyDecouplingLayout(soup, { clearance: 0.5 })
+
+    expect(placements).toHaveLength(1)
+    const [p] = placements
+
+    // Should be 0.5 mm outward (positive Y) from the IC pin at (4, 6).
+    expect(p.position.x).toBeCloseTo(4)
+    expect(p.position.y).toBeCloseTo(6.5)
+    expect(p.rotation).toBe(90)
+  })
+
+  it("updates pcb_component position in-place", () => {
+    const soup = makeSoup("right", { x: 10, y: 2 }, "VCC")
+    applyDecouplingLayout(soup, { clearance: 1.0 })
+
+    const pcb = soup.pcb_components!.find((c) => c.source_component_id === "C1")!
+    expect(pcb.x).toBeCloseTo(11)
+    expect(pcb.y).toBeCloseTo(2)
+    expect(pcb.rotation).toBe(0)
+  })
+
+  it("handles AGND decap end-to-end", () => {
+    const soup = makeSoup("bottom", { x: 0, y: -5 }, "AGND")
+    const [p] = applyDecouplingLayout(soup, { clearance: 0.5 })
+
+    expect(p.net).toBe("AGND")
+    expect(p.position.x).toBeCloseTo(0)
+    expect(p.position.y).toBeCloseTo(-5.5)
+  })
+})

--- a/lib/layouts/apply-decoupling-layout.ts
+++ b/lib/layouts/apply-decoupling-layout.ts
@@ -1,421 +1,87 @@
 /**
  * apply-decoupling-layout.ts
  *
- * Integrates the decoupling capacitor layout algorithm with the matchpack
- * circuit-soup / soup-element pipeline.
+ * Integrates `layoutDecouplingCapacitors` with the matchpack "soup" element
+ * format.  Reads `source_component`, `source_port`, `source_net`, and
+ * `source_trace` elements to:
  *
- * Given a parsed circuit soup (array of elements), this function:
- *   1. Finds the primary IC component.
- *   2. Identifies its power/ground pins.
- *   3. Finds the decoupling capacitors connected to those pins.
- *   4. Calls layoutDecouplingCapacitors() to compute optimal positions.
- *   5. Returns a new soup with updated pcb_component positions/rotations for
- *      every decoupling capacitor.
- *
- * Issue: https://github.com/tscircuit/matchpack/issues/15
+ *   1. Identify which source components are decoupling capacitors
+ *      (`buildDecapMap`).
+ *   2. Resolve the reference IC power-pin position/side for each decap from
+ *      the IC ports that share the same net (`buildIcPowerPinsByNetId`).
+ *   3. Run the placement algorithm.
+ *   4. Write the resulting `x/y/rotation` back to the corresponding
+ *      `pcb_component` elements.
  */
 
 import {
   layoutDecouplingCapacitors,
+  filterDecouplingPins,
   isPowerNet,
-  type ComponentBounds,
   type PinInfo,
-  type DecouplingCapacitorLayoutOptions,
+  type Side,
+  type DecapPlacement,
+  type DecapLayoutOptions,
 } from "./decoupling-capacitor-layout"
 
 // ---------------------------------------------------------------------------
-// Minimal soup element types (mirrors what tscircuit uses)
+// Soup element type stubs
+// (matchpack's actual soup types are duck-typed; we only reference the fields
+//  we need so the file stays self-contained.)
 // ---------------------------------------------------------------------------
 
-interface SoupElement {
-  type: string
-  [key: string]: unknown
-}
-
-interface PcbComponent extends SoupElement {
-  type: "pcb_component"
-  pcb_component_id: string
+interface SourceComponent {
   source_component_id: string
-  center: { x: number; y: number }
-  width: number
-  height: number
-  rotation: number
-  layer: string
-}
-
-interface SourceComponent extends SoupElement {
-  type: "source_component"
-  source_component_id: string
-  name: string
+  name?: string
+  /** e.g. "capacitor", "resistor", "chip", … */
   ftype?: string
-  // Additional fields vary by component type
+  supplier_part_numbers?: Record<string, string[]>
+  properties?: Record<string, string>
 }
 
-interface SourcePort extends SoupElement {
-  type: "source_port"
+interface SourcePort {
   source_port_id: string
   source_component_id: string
-  name: string
+  name?: string
   pin_number?: number
+  /** Pre-computed position (present on IC ports when schematic has been laid out) */
+  position?: { x: number; y: number }
+  /** Which side of the package this port is on */
+  side?: Side
 }
 
-interface SourceNet extends SoupElement {
-  type: "source_net"
+interface SourceNet {
   source_net_id: string
   name: string
 }
 
-interface SourceTrace extends SoupElement {
-  type: "source_trace"
+interface SourceTrace {
   source_trace_id: string
   connected_source_port_ids: string[]
-  connected_source_net_ids: string[]
+  connected_source_net_id?: string
 }
 
-interface PcbPort extends SoupElement {
-  type: "pcb_port"
-  pcb_port_id: string
-  source_port_id: string
+interface PcbComponent {
   pcb_component_id: string
-  x: number
-  y: number
-  layers: string[]
+  source_component_id: string
+  center?: { x: number; y: number }
+  x?: number
+  y?: number
+  rotation?: number
+  layer?: string
+}
+
+export interface SoupElements {
+  source_components?: SourceComponent[]
+  source_ports?: SourcePort[]
+  source_nets?: SourceNet[]
+  source_traces?: SourceTrace[]
+  pcb_components?: PcbComponent[]
 }
 
 // ---------------------------------------------------------------------------
-// Main function
+// Helper: stable integer hash for a string (used as fallback pinNumber)
 // ---------------------------------------------------------------------------
-
-export interface ApplyDecouplingLayoutOptions
-  extends DecouplingCapacitorLayoutOptions {
-  /**
-   * source_component_id of the main IC to process.
-   * If omitted, the function attempts to auto-detect the largest / primary IC.
-   */
-  icComponentId?: string
-
-  /**
-   * Names (or regexes) of component types to treat as decoupling capacitors.
-   * Defaults to any component whose ftype/name includes "cap" or "C".
-   */
-  capComponentIds?: string[]
-}
-
-/**
- * Apply a clean decoupling-capacitor layout to a matchpack soup.
- *
- * Returns a new soup array with updated `pcb_component` positions/rotations
- * for all identified decoupling capacitors.
- */
-export function applyDecouplingLayout(
-  soup: SoupElement[],
-  options: ApplyDecouplingLayoutOptions = {},
-): SoupElement[] {
-  const { icComponentId, capComponentIds, ...layoutOptions } = options
-
-  // Index elements by type for fast lookup
-  const byType = groupByType(soup)
-
-  const pcbComponents = (byType["pcb_component"] ?? []) as PcbComponent[]
-  const sourceComponents = (byType["source_component"] ??
-    []) as SourceComponent[]
-  const sourcePorts = (byType["source_port"] ?? []) as SourcePort[]
-  const sourceNets = (byType["source_net"] ?? []) as SourceNet[]
-  const sourceTraces = (byType["source_trace"] ?? []) as SourceTrace[]
-  const pcbPorts = (byType["pcb_port"] ?? []) as PcbPort[]
-
-  // ---- 1. Find the IC -------------------------------------------------
-  const ic = findIC(sourceComponents, pcbComponents, icComponentId)
-  if (!ic) {
-    // Nothing to do
-    return soup
-  }
-
-  const icPcb = pcbComponents.find(
-    (c) => c.source_component_id === ic.source_component_id,
-  )
-  if (!icPcb) return soup
-
-  const chipBounds: ComponentBounds = {
-    centre: { x: icPcb.center.x, y: icPcb.center.y },
-    width: icPcb.width,
-    height: icPcb.height,
-  }
-
-  // ---- 2. Build a net-name index for port → net name ------------------
-  const portNetName = buildPortNetIndex(sourcePorts, sourceNets, sourceTraces)
-
-  // ---- 3. Identify power ports on the IC ------------------------------
-  const icSourcePorts = sourcePorts.filter(
-    (p) => p.source_component_id === ic.source_component_id,
-  )
-
-  const powerPorts = icSourcePorts.filter((p) => {
-    const net = portNetName[p.source_port_id]
-    return net ? isPowerNet(net) : false
-  })
-
-  if (powerPorts.length === 0) return soup
-
-  // ---- 4. Build PinInfo for each power port ---------------------------
-  const icPcbPorts = pcbPorts.filter((pp) => pp.pcb_component_id === icPcb.pcb_component_id)
-
-  const pins: PinInfo[] = powerPorts.flatMap((sp) => {
-    const pcbPort = icPcbPorts.find((pp) => pp.source_port_id === sp.source_port_id)
-    if (!pcbPort) return []
-
-    const side = classifySide(
-      { x: pcbPort.x, y: pcbPort.y },
-      chipBounds,
-    )
-    const net = portNetName[sp.source_port_id] ?? ""
-
-    return [
-      {
-        pinNumber: sp.pin_number ?? derivePin(sp.name),
-        net,
-        position: { x: pcbPort.x, y: pcbPort.y },
-        side,
-      } satisfies PinInfo,
-    ]
-  })
-
-  if (pins.length === 0) return soup
-
-  // ---- 5. Find decoupling capacitors connected to those power nets -----
-  const powerNetIds = new Set<string>()
-  for (const sp of powerPorts) {
-    const netId = findNetId(sp.source_port_id, sourceTraces)
-    if (netId) powerNetIds.add(netId)
-  }
-
-  // Map: source_component_id → the power pin it decouples
-  const decapMap = buildDecapMap(
-    sourceComponents,
-    sourcePorts,
-    sourceTraces,
-    powerNetIds,
-    ic.source_component_id,
-    capComponentIds,
-  )
-
-  if (decapMap.size === 0) return soup
-
-  // ---- 6. Run layout --------------------------------------------------
-  // Create a pin entry per decoupling cap (using the IC power pin position)
-  const capPins: PinInfo[] = []
-  for (const [capSrcId, pinInfo] of decapMap.entries()) {
-    capPins.push({ ...pinInfo, pinNumber: hashString(capSrcId) })
-  }
-
-  const placements = layoutDecouplingCapacitors(chipBounds, capPins, layoutOptions)
-
-  // ---- 7. Apply placements back to soup elements ----------------------
-  const updatedIds = new Set<string>()
-  const capSrcIds = [...decapMap.keys()]
-
-  const newSoup = soup.map((el) => {
-    if (el.type !== "pcb_component") return el
-    const pcbComp = el as PcbComponent
-    const srcId = pcbComp.source_component_id
-    const idx = capSrcIds.indexOf(srcId)
-    if (idx === -1) return el
-
-    const placement = placements[idx]
-    if (!placement) return el
-
-    updatedIds.add(srcId)
-    return {
-      ...pcbComp,
-      center: placement.position,
-      rotation: placement.rotation,
-    } as PcbComponent
-  })
-
-  return newSoup
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function groupByType(
-  soup: SoupElement[],
-): Record<string, SoupElement[]> {
-  const result: Record<string, SoupElement[]> = {}
-  for (const el of soup) {
-    if (!result[el.type]) result[el.type] = []
-    result[el.type].push(el)
-  }
-  return result
-}
-
-function findIC(
-  sourceComponents: SourceComponent[],
-  pcbComponents: PcbComponent[],
-  icComponentId?: string,
-): SourceComponent | undefined {
-  if (icComponentId) {
-    return sourceComponents.find(
-      (c) => c.source_component_id === icComponentId,
-    )
-  }
-
-  // Heuristic: the component with the largest pcb footprint area is the IC
-  let best: SourceComponent | undefined
-  let bestArea = -1
-
-  for (const sc of sourceComponents) {
-    const pcb = pcbComponents.find(
-      (p) => p.source_component_id === sc.source_component_id,
-    )
-    if (!pcb) continue
-    const area = pcb.width * pcb.height
-    if (area > bestArea) {
-      bestArea = area
-      best = sc
-    }
-  }
-
-  return best
-}
-
-function buildPortNetIndex(
-  sourcePorts: SourcePort[],
-  sourceNets: SourceNet[],
-  sourceTraces: SourceTrace[],
-): Record<string, string> {
-  const netIdToName: Record<string, string> = {}
-  for (const net of sourceNets) {
-    netIdToName[net.source_net_id] = net.name
-  }
-
-  const portToNet: Record<string, string> = {}
-  for (const trace of sourceTraces) {
-    const netIds = trace.connected_source_net_ids
-    const portIds = trace.connected_source_port_ids
-    for (const netId of netIds) {
-      const netName = netIdToName[netId]
-      if (!netName) continue
-      for (const portId of portIds) {
-        portToNet[portId] = netName
-      }
-    }
-  }
-
-  return portToNet
-}
-
-function findNetId(
-  portId: string,
-  sourceTraces: SourceTrace[],
-): string | undefined {
-  for (const trace of sourceTraces) {
-    if (trace.connected_source_port_ids.includes(portId)) {
-      return trace.connected_source_net_ids[0]
-    }
-  }
-  return undefined
-}
-
-/**
- * Determine which side of the chip a port falls on, based on proximity to each
- * edge of the chip bounding box.
- */
-function classifySide(
-  portPos: { x: number; y: number },
-  chip: ComponentBounds,
-): "top" | "bottom" | "left" | "right" {
-  const dx = portPos.x - chip.centre.x
-  const dy = portPos.y - chip.centre.y
-
-  const fromRight = chip.width / 2 - Math.abs(dx)
-  const fromTop = chip.height / 2 - Math.abs(dy)
-
-  if (fromRight < fromTop) {
-    return dx > 0 ? "right" : "left"
-  } else {
-    return dy > 0 ? "top" : "bottom"
-  }
-}
-
-/**
- * Build a map from decoupling-capacitor source_component_id → PinInfo of the
- * IC power pin it is associated with.
- *
- * A component is considered a decoupling capacitor if:
- *   - It is in capComponentIds (if provided), OR
- *   - Its name starts with "C" and it has exactly two ports, one of which
- *     is connected to a power net of the IC.
- */
-function buildDecapMap(
-  sourceComponents: SourceComponent[],
-  sourcePorts: SourcePort[],
-  sourceTraces: SourceTrace[],
-  powerNetIds: Set<string>,
-  icSrcId: string,
-  capComponentIds?: string[],
-): Map<string, PinInfo> {
-  const result = new Map<string, PinInfo>()
-
-  const capSet = capComponentIds ? new Set(capComponentIds) : null
-
-  // Build port → netId index
-  const portToNetId: Record<string, string> = {}
-  for (const trace of sourceTraces) {
-    for (const portId of trace.connected_source_port_ids) {
-      if (trace.connected_source_net_ids[0]) {
-        portToNetId[portId] = trace.connected_source_net_ids[0]
-      }
-    }
-  }
-
-  const portsByComponent: Record<string, SourcePort[]> = {}
-  for (const port of sourcePorts) {
-    if (!portsByComponent[port.source_component_id]) {
-      portsByComponent[port.source_component_id] = []
-    }
-    portsByComponent[port.source_component_id].push(port)
-  }
-
-  for (const sc of sourceComponents) {
-    if (sc.source_component_id === icSrcId) continue
-
-    const isCapByList = capSet?.has(sc.source_component_id)
-    const isCapByName =
-      !capSet &&
-      typeof sc.name === "string" &&
-      /^C\d*$|^cap/i.test(sc.name)
-
-    if (!isCapByList && !isCapByName) continue
-
-    const ports = portsByComponent[sc.source_component_id] ?? []
-    if (ports.length !== 2) continue
-
-    for (const port of ports) {
-      const netId = portToNetId[port.source_port_id]
-      if (netId && powerNetIds.has(netId)) {
-        // This capacitor is connected to a power net — it's a decoupling cap
-        // Use a placeholder PinInfo; actual position will be the IC pin position
-        // (resolved during layoutDecouplingCapacitors call)
-        result.set(sc.source_component_id, {
-          pinNumber: hashString(sc.source_component_id),
-          net: netId,
-          position: { x: 0, y: 0 }, // placeholder
-          side: "top", // placeholder — overridden by actual pin position
-        })
-        break
-      }
-    }
-  }
-
-  return result
-}
-
-function derivePin(name: string): number {
-  const m = name.match(/\d+/)
-  return m ? parseInt(m[0], 10) : 0
-}
 
 function hashString(s: string): number {
   let h = 0
@@ -423,4 +89,234 @@ function hashString(s: string): number {
     h = (Math.imul(31, h) + s.charCodeAt(i)) | 0
   }
   return Math.abs(h)
+}
+
+// ---------------------------------------------------------------------------
+// Helper: determine whether a SourceComponent looks like a capacitor
+// ---------------------------------------------------------------------------
+
+function isCapacitor(sc: SourceComponent): boolean {
+  if (sc.ftype?.toLowerCase().includes("capacitor")) return true
+  if (sc.name?.toLowerCase().startsWith("c")) return true
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Helper: determine whether a SourceComponent looks like an IC / chip
+// ---------------------------------------------------------------------------
+
+function isIc(sc: SourceComponent): boolean {
+  const ftype = sc.ftype?.toLowerCase() ?? ""
+  return (
+    ftype.includes("chip") ||
+    ftype.includes("ic") ||
+    ftype.includes("microcontroller") ||
+    ftype.includes("mcu") ||
+    ftype.includes("fpga") ||
+    ftype.includes("regulator") ||
+    ftype === "simple_chip"
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Build a map: netId → PinInfo for IC power pins
+// ---------------------------------------------------------------------------
+
+/**
+ * Scans all IC source_ports that belong to a power net and returns a map
+ * keyed by `source_net_id`.  Only the *first* IC power port found for each
+ * net is stored; later decaps on the same net reuse that reference position.
+ *
+ * If a net has multiple IC power pins (e.g. several VDD pins) the algorithm
+ * will still place each decap relative to the closest pin — but resolving
+ * "closest" requires PCB coordinates which may not yet be available.  As a
+ * pragmatic fallback we use the first match.
+ */
+function buildIcPowerPinsByNetId(
+  elements: SoupElements,
+): Map<string, PinInfo> {
+  const {
+    source_components = [],
+    source_ports = [],
+    source_nets = [],
+    source_traces = [],
+  } = elements
+
+  // Index
+  const netById = new Map<string, SourceNet>(
+    source_nets.map((n) => [n.source_net_id, n]),
+  )
+  const portById = new Map<string, SourcePort>(
+    source_ports.map((p) => [p.source_port_id, p]),
+  )
+  const icIds = new Set<string>(
+    source_components.filter(isIc).map((c) => c.source_component_id),
+  )
+
+  // For each trace that connects to a power net, find any IC port on that net.
+  const result = new Map<string, PinInfo>()
+
+  for (const trace of source_traces) {
+    const { connected_source_net_id: netId, connected_source_port_ids: portIds } =
+      trace
+    if (!netId) continue
+    const net = netById.get(netId)
+    if (!net || !isPowerNet(net.name)) continue
+
+    for (const portId of portIds) {
+      const port = portById.get(portId)
+      if (!port) continue
+      if (!icIds.has(port.source_component_id)) continue
+
+      // We have an IC port on a power net.
+      if (result.has(netId)) continue // already recorded one for this net
+
+      result.set(netId, {
+        pinNumber: port.pin_number ?? hashString(portId),
+        net: net.name,
+        position: port.position ?? { x: 0, y: 0 },
+        side: port.side ?? "top",
+      })
+    }
+  }
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Build the decap map consumed by layoutDecouplingCapacitors
+// ---------------------------------------------------------------------------
+
+/**
+ * For each capacitor source component that is connected to a power net,
+ * builds a `PinInfo` record anchored to the IC power pin on that same net.
+ *
+ * The `position` and `side` fields come from `icPowerPinsByNetId` so that
+ * the layout algorithm places every decap adjacent to the real IC pin rather
+ * than at the origin.
+ */
+export function buildDecapMap(
+  elements: SoupElements,
+): Map<string, PinInfo> {
+  const {
+    source_components = [],
+    source_nets = [],
+    source_traces = [],
+    source_ports = [],
+  } = elements
+
+  const netById = new Map<string, SourceNet>(
+    source_nets.map((n) => [n.source_net_id, n]),
+  )
+  // Map source_component_id → its ports
+  const portsByComponent = new Map<string, SourcePort[]>()
+  for (const port of source_ports) {
+    const arr = portsByComponent.get(port.source_component_id) ?? []
+    arr.push(port)
+    portsByComponent.set(port.source_component_id, arr)
+  }
+
+  // Resolve IC power-pin reference positions for every power net.
+  const icPowerPinsByNetId = buildIcPowerPinsByNetId(elements)
+
+  // Build a quick lookup: portId → netId (from traces)
+  const netIdByPortId = new Map<string, string>()
+  for (const trace of source_traces) {
+    if (!trace.connected_source_net_id) continue
+    for (const portId of trace.connected_source_port_ids) {
+      netIdByPortId.set(portId, trace.connected_source_net_id)
+    }
+  }
+
+  const result = new Map<string, PinInfo>()
+
+  for (const sc of source_components) {
+    if (!isCapacitor(sc)) continue
+
+    const ports = portsByComponent.get(sc.source_component_id) ?? []
+
+    // A decoupling cap has at least one port connected to a power net.
+    // Find the first such port.
+    let powerNetId: string | undefined
+    for (const port of ports) {
+      const netId = netIdByPortId.get(port.source_port_id)
+      if (!netId) continue
+      const net = netById.get(netId)
+      if (net && isPowerNet(net.name)) {
+        powerNetId = netId
+        break
+      }
+    }
+
+    if (!powerNetId) continue // not a decoupling cap
+
+    const net = netById.get(powerNetId)!
+
+    // Resolve the IC power-pin info for this net.
+    // This gives us the real position + side so the placement is anchored
+    // to the correct IC pin rather than defaulting to (0,0) / "top".
+    const icPinInfo = icPowerPinsByNetId.get(powerNetId)
+
+    result.set(sc.source_component_id, {
+      pinNumber: icPinInfo?.pinNumber ?? hashString(sc.source_component_id),
+      net: net.name,
+      position: icPinInfo?.position ?? { x: 0, y: 0 },
+      side: icPinInfo?.side ?? "top",
+    })
+  }
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs the full decoupling-capacitor layout pass on `elements`:
+ *
+ * 1. Builds the decap map (with real IC pin positions/sides).
+ * 2. Calls `layoutDecouplingCapacitors`.
+ * 3. Applies the resulting placements to `pcb_components` in-place.
+ *
+ * Returns the list of computed placements (useful for testing / previewing).
+ */
+export function applyDecouplingLayout(
+  elements: SoupElements,
+  options: DecapLayoutOptions = {},
+): DecapPlacement[] {
+  const decapMap = buildDecapMap(elements)
+
+  // Filter to only power-net-connected decaps (redundant given buildDecapMap,
+  // but keeps the pipeline explicit and matches the filterDecouplingPins API).
+  const filteredMap = new Map<string, PinInfo>()
+  for (const [id, pinInfo] of decapMap) {
+    if (isPowerNet(pinInfo.net)) {
+      filteredMap.set(id, pinInfo)
+    }
+  }
+
+  const placements = layoutDecouplingCapacitors(filteredMap, options)
+
+  // Write placements back into pcb_components.
+  if (elements.pcb_components) {
+    const pcbById = new Map<string, PcbComponent>(
+      elements.pcb_components.map((c) => [c.source_component_id, c]),
+    )
+
+    for (const placement of placements) {
+      const pcb = pcbById.get(placement.componentId)
+      if (!pcb) continue
+      // Support both center-object and flat x/y formats.
+      if (pcb.center !== undefined) {
+        pcb.center = placement.position
+      } else {
+        pcb.x = placement.position.x
+        pcb.y = placement.position.y
+      }
+      pcb.rotation = placement.rotation
+    }
+  }
+
+  return placements
 }

--- a/lib/layouts/apply-decoupling-layout.ts
+++ b/lib/layouts/apply-decoupling-layout.ts
@@ -1,0 +1,426 @@
+/**
+ * apply-decoupling-layout.ts
+ *
+ * Integrates the decoupling capacitor layout algorithm with the matchpack
+ * circuit-soup / soup-element pipeline.
+ *
+ * Given a parsed circuit soup (array of elements), this function:
+ *   1. Finds the primary IC component.
+ *   2. Identifies its power/ground pins.
+ *   3. Finds the decoupling capacitors connected to those pins.
+ *   4. Calls layoutDecouplingCapacitors() to compute optimal positions.
+ *   5. Returns a new soup with updated pcb_component positions/rotations for
+ *      every decoupling capacitor.
+ *
+ * Issue: https://github.com/tscircuit/matchpack/issues/15
+ */
+
+import {
+  layoutDecouplingCapacitors,
+  isPowerNet,
+  type ComponentBounds,
+  type PinInfo,
+  type DecouplingCapacitorLayoutOptions,
+} from "./decoupling-capacitor-layout"
+
+// ---------------------------------------------------------------------------
+// Minimal soup element types (mirrors what tscircuit uses)
+// ---------------------------------------------------------------------------
+
+interface SoupElement {
+  type: string
+  [key: string]: unknown
+}
+
+interface PcbComponent extends SoupElement {
+  type: "pcb_component"
+  pcb_component_id: string
+  source_component_id: string
+  center: { x: number; y: number }
+  width: number
+  height: number
+  rotation: number
+  layer: string
+}
+
+interface SourceComponent extends SoupElement {
+  type: "source_component"
+  source_component_id: string
+  name: string
+  ftype?: string
+  // Additional fields vary by component type
+}
+
+interface SourcePort extends SoupElement {
+  type: "source_port"
+  source_port_id: string
+  source_component_id: string
+  name: string
+  pin_number?: number
+}
+
+interface SourceNet extends SoupElement {
+  type: "source_net"
+  source_net_id: string
+  name: string
+}
+
+interface SourceTrace extends SoupElement {
+  type: "source_trace"
+  source_trace_id: string
+  connected_source_port_ids: string[]
+  connected_source_net_ids: string[]
+}
+
+interface PcbPort extends SoupElement {
+  type: "pcb_port"
+  pcb_port_id: string
+  source_port_id: string
+  pcb_component_id: string
+  x: number
+  y: number
+  layers: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Main function
+// ---------------------------------------------------------------------------
+
+export interface ApplyDecouplingLayoutOptions
+  extends DecouplingCapacitorLayoutOptions {
+  /**
+   * source_component_id of the main IC to process.
+   * If omitted, the function attempts to auto-detect the largest / primary IC.
+   */
+  icComponentId?: string
+
+  /**
+   * Names (or regexes) of component types to treat as decoupling capacitors.
+   * Defaults to any component whose ftype/name includes "cap" or "C".
+   */
+  capComponentIds?: string[]
+}
+
+/**
+ * Apply a clean decoupling-capacitor layout to a matchpack soup.
+ *
+ * Returns a new soup array with updated `pcb_component` positions/rotations
+ * for all identified decoupling capacitors.
+ */
+export function applyDecouplingLayout(
+  soup: SoupElement[],
+  options: ApplyDecouplingLayoutOptions = {},
+): SoupElement[] {
+  const { icComponentId, capComponentIds, ...layoutOptions } = options
+
+  // Index elements by type for fast lookup
+  const byType = groupByType(soup)
+
+  const pcbComponents = (byType["pcb_component"] ?? []) as PcbComponent[]
+  const sourceComponents = (byType["source_component"] ??
+    []) as SourceComponent[]
+  const sourcePorts = (byType["source_port"] ?? []) as SourcePort[]
+  const sourceNets = (byType["source_net"] ?? []) as SourceNet[]
+  const sourceTraces = (byType["source_trace"] ?? []) as SourceTrace[]
+  const pcbPorts = (byType["pcb_port"] ?? []) as PcbPort[]
+
+  // ---- 1. Find the IC -------------------------------------------------
+  const ic = findIC(sourceComponents, pcbComponents, icComponentId)
+  if (!ic) {
+    // Nothing to do
+    return soup
+  }
+
+  const icPcb = pcbComponents.find(
+    (c) => c.source_component_id === ic.source_component_id,
+  )
+  if (!icPcb) return soup
+
+  const chipBounds: ComponentBounds = {
+    centre: { x: icPcb.center.x, y: icPcb.center.y },
+    width: icPcb.width,
+    height: icPcb.height,
+  }
+
+  // ---- 2. Build a net-name index for port → net name ------------------
+  const portNetName = buildPortNetIndex(sourcePorts, sourceNets, sourceTraces)
+
+  // ---- 3. Identify power ports on the IC ------------------------------
+  const icSourcePorts = sourcePorts.filter(
+    (p) => p.source_component_id === ic.source_component_id,
+  )
+
+  const powerPorts = icSourcePorts.filter((p) => {
+    const net = portNetName[p.source_port_id]
+    return net ? isPowerNet(net) : false
+  })
+
+  if (powerPorts.length === 0) return soup
+
+  // ---- 4. Build PinInfo for each power port ---------------------------
+  const icPcbPorts = pcbPorts.filter((pp) => pp.pcb_component_id === icPcb.pcb_component_id)
+
+  const pins: PinInfo[] = powerPorts.flatMap((sp) => {
+    const pcbPort = icPcbPorts.find((pp) => pp.source_port_id === sp.source_port_id)
+    if (!pcbPort) return []
+
+    const side = classifySide(
+      { x: pcbPort.x, y: pcbPort.y },
+      chipBounds,
+    )
+    const net = portNetName[sp.source_port_id] ?? ""
+
+    return [
+      {
+        pinNumber: sp.pin_number ?? derivePin(sp.name),
+        net,
+        position: { x: pcbPort.x, y: pcbPort.y },
+        side,
+      } satisfies PinInfo,
+    ]
+  })
+
+  if (pins.length === 0) return soup
+
+  // ---- 5. Find decoupling capacitors connected to those power nets -----
+  const powerNetIds = new Set<string>()
+  for (const sp of powerPorts) {
+    const netId = findNetId(sp.source_port_id, sourceTraces)
+    if (netId) powerNetIds.add(netId)
+  }
+
+  // Map: source_component_id → the power pin it decouples
+  const decapMap = buildDecapMap(
+    sourceComponents,
+    sourcePorts,
+    sourceTraces,
+    powerNetIds,
+    ic.source_component_id,
+    capComponentIds,
+  )
+
+  if (decapMap.size === 0) return soup
+
+  // ---- 6. Run layout --------------------------------------------------
+  // Create a pin entry per decoupling cap (using the IC power pin position)
+  const capPins: PinInfo[] = []
+  for (const [capSrcId, pinInfo] of decapMap.entries()) {
+    capPins.push({ ...pinInfo, pinNumber: hashString(capSrcId) })
+  }
+
+  const placements = layoutDecouplingCapacitors(chipBounds, capPins, layoutOptions)
+
+  // ---- 7. Apply placements back to soup elements ----------------------
+  const updatedIds = new Set<string>()
+  const capSrcIds = [...decapMap.keys()]
+
+  const newSoup = soup.map((el) => {
+    if (el.type !== "pcb_component") return el
+    const pcbComp = el as PcbComponent
+    const srcId = pcbComp.source_component_id
+    const idx = capSrcIds.indexOf(srcId)
+    if (idx === -1) return el
+
+    const placement = placements[idx]
+    if (!placement) return el
+
+    updatedIds.add(srcId)
+    return {
+      ...pcbComp,
+      center: placement.position,
+      rotation: placement.rotation,
+    } as PcbComponent
+  })
+
+  return newSoup
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function groupByType(
+  soup: SoupElement[],
+): Record<string, SoupElement[]> {
+  const result: Record<string, SoupElement[]> = {}
+  for (const el of soup) {
+    if (!result[el.type]) result[el.type] = []
+    result[el.type].push(el)
+  }
+  return result
+}
+
+function findIC(
+  sourceComponents: SourceComponent[],
+  pcbComponents: PcbComponent[],
+  icComponentId?: string,
+): SourceComponent | undefined {
+  if (icComponentId) {
+    return sourceComponents.find(
+      (c) => c.source_component_id === icComponentId,
+    )
+  }
+
+  // Heuristic: the component with the largest pcb footprint area is the IC
+  let best: SourceComponent | undefined
+  let bestArea = -1
+
+  for (const sc of sourceComponents) {
+    const pcb = pcbComponents.find(
+      (p) => p.source_component_id === sc.source_component_id,
+    )
+    if (!pcb) continue
+    const area = pcb.width * pcb.height
+    if (area > bestArea) {
+      bestArea = area
+      best = sc
+    }
+  }
+
+  return best
+}
+
+function buildPortNetIndex(
+  sourcePorts: SourcePort[],
+  sourceNets: SourceNet[],
+  sourceTraces: SourceTrace[],
+): Record<string, string> {
+  const netIdToName: Record<string, string> = {}
+  for (const net of sourceNets) {
+    netIdToName[net.source_net_id] = net.name
+  }
+
+  const portToNet: Record<string, string> = {}
+  for (const trace of sourceTraces) {
+    const netIds = trace.connected_source_net_ids
+    const portIds = trace.connected_source_port_ids
+    for (const netId of netIds) {
+      const netName = netIdToName[netId]
+      if (!netName) continue
+      for (const portId of portIds) {
+        portToNet[portId] = netName
+      }
+    }
+  }
+
+  return portToNet
+}
+
+function findNetId(
+  portId: string,
+  sourceTraces: SourceTrace[],
+): string | undefined {
+  for (const trace of sourceTraces) {
+    if (trace.connected_source_port_ids.includes(portId)) {
+      return trace.connected_source_net_ids[0]
+    }
+  }
+  return undefined
+}
+
+/**
+ * Determine which side of the chip a port falls on, based on proximity to each
+ * edge of the chip bounding box.
+ */
+function classifySide(
+  portPos: { x: number; y: number },
+  chip: ComponentBounds,
+): "top" | "bottom" | "left" | "right" {
+  const dx = portPos.x - chip.centre.x
+  const dy = portPos.y - chip.centre.y
+
+  const fromRight = chip.width / 2 - Math.abs(dx)
+  const fromTop = chip.height / 2 - Math.abs(dy)
+
+  if (fromRight < fromTop) {
+    return dx > 0 ? "right" : "left"
+  } else {
+    return dy > 0 ? "top" : "bottom"
+  }
+}
+
+/**
+ * Build a map from decoupling-capacitor source_component_id → PinInfo of the
+ * IC power pin it is associated with.
+ *
+ * A component is considered a decoupling capacitor if:
+ *   - It is in capComponentIds (if provided), OR
+ *   - Its name starts with "C" and it has exactly two ports, one of which
+ *     is connected to a power net of the IC.
+ */
+function buildDecapMap(
+  sourceComponents: SourceComponent[],
+  sourcePorts: SourcePort[],
+  sourceTraces: SourceTrace[],
+  powerNetIds: Set<string>,
+  icSrcId: string,
+  capComponentIds?: string[],
+): Map<string, PinInfo> {
+  const result = new Map<string, PinInfo>()
+
+  const capSet = capComponentIds ? new Set(capComponentIds) : null
+
+  // Build port → netId index
+  const portToNetId: Record<string, string> = {}
+  for (const trace of sourceTraces) {
+    for (const portId of trace.connected_source_port_ids) {
+      if (trace.connected_source_net_ids[0]) {
+        portToNetId[portId] = trace.connected_source_net_ids[0]
+      }
+    }
+  }
+
+  const portsByComponent: Record<string, SourcePort[]> = {}
+  for (const port of sourcePorts) {
+    if (!portsByComponent[port.source_component_id]) {
+      portsByComponent[port.source_component_id] = []
+    }
+    portsByComponent[port.source_component_id].push(port)
+  }
+
+  for (const sc of sourceComponents) {
+    if (sc.source_component_id === icSrcId) continue
+
+    const isCapByList = capSet?.has(sc.source_component_id)
+    const isCapByName =
+      !capSet &&
+      typeof sc.name === "string" &&
+      /^C\d*$|^cap/i.test(sc.name)
+
+    if (!isCapByList && !isCapByName) continue
+
+    const ports = portsByComponent[sc.source_component_id] ?? []
+    if (ports.length !== 2) continue
+
+    for (const port of ports) {
+      const netId = portToNetId[port.source_port_id]
+      if (netId && powerNetIds.has(netId)) {
+        // This capacitor is connected to a power net — it's a decoupling cap
+        // Use a placeholder PinInfo; actual position will be the IC pin position
+        // (resolved during layoutDecouplingCapacitors call)
+        result.set(sc.source_component_id, {
+          pinNumber: hashString(sc.source_component_id),
+          net: netId,
+          position: { x: 0, y: 0 }, // placeholder
+          side: "top", // placeholder — overridden by actual pin position
+        })
+        break
+      }
+    }
+  }
+
+  return result
+}
+
+function derivePin(name: string): number {
+  const m = name.match(/\d+/)
+  return m ? parseInt(m[0], 10) : 0
+}
+
+function hashString(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) {
+    h = (Math.imul(31, h) + s.charCodeAt(i)) | 0
+  }
+  return Math.abs(h)
+}

--- a/lib/layouts/decoupling-capacitor-layout.test.ts
+++ b/lib/layouts/decoupling-capacitor-layout.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest"
+import {
+  layoutDecouplingCapacitors,
+  filterDecouplingPins,
+  isPowerNet,
+  type ComponentBounds,
+  type PinInfo,
+} from "./decoupling-capacitor-layout"
+
+// ---------------------------------------------------------------------------
+// isPowerNet
+// ---------------------------------------------------------------------------
+describe("isPowerNet", () => {
+  it("matches common power nets", () => {
+    expect(isPowerNet("VDD")).toBe(true)
+    expect(isPowerNet("VCC")).toBe(true)
+    expect(isPowerNet("GND")).toBe(true)
+    expect(isPowerNet("VSS")).toBe(true)
+    expect(isPowerNet("AVDD")).toBe(true)
+    expect(isPowerNet("DVDD")).toBe(true)
+    expect(isPowerNet("3V3")).toBe(true)
+    expect(isPowerNet("1V8")).toBe(true)
+  })
+
+  it("does not match signal nets", () => {
+    expect(isPowerNet("CLK")).toBe(false)
+    expect(isPowerNet("MISO")).toBe(false)
+    expect(isPowerNet("GPIO0")).toBe(false)
+    expect(isPowerNet("TX")).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// filterDecouplingPins
+// ---------------------------------------------------------------------------
+describe("filterDecouplingPins", () => {
+  const pins: PinInfo[] = [
+    { pinNumber: 1, net: "VDD", position: { x: 0, y: 2 }, side: "top" },
+    { pinNumber: 2, net: "CLK", position: { x: 1, y: 2 }, side: "top" },
+    { pinNumber: 3, net: "GND", position: { x: 0, y: -2 }, side: "bottom" },
+    { pinNumber: 4, net: "MISO", position: { x: -2, y: 0 }, side: "left" },
+  ]
+
+  it("returns only power / ground pins", () => {
+    const filtered = filterDecouplingPins(pins)
+    expect(filtered).toHaveLength(2)
+    expect(filtered.map((p) => p.net)).toEqual(["VDD", "GND"])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// layoutDecouplingCapacitors — basic geometry
+// ---------------------------------------------------------------------------
+describe("layoutDecouplingCapacitors", () => {
+  const chip: ComponentBounds = {
+    centre: { x: 0, y: 0 },
+    width: 4, // ±2 mm from centre
+    height: 4,
+  }
+
+  it("places a top-side cap above the chip", () => {
+    const pins: PinInfo[] = [
+      { pinNumber: 1, net: "VDD", position: { x: 0, y: 2 }, side: "top" },
+    ]
+    const [placement] = layoutDecouplingCapacitors(chip, pins)
+    expect(placement.position.y).toBeGreaterThan(2) // above chip edge
+    expect(placement.rotation).toBe(0)
+  })
+
+  it("places a bottom-side cap below the chip", () => {
+    const pins: PinInfo[] = [
+      { pinNumber: 5, net: "GND", position: { x: 0, y: -2 }, side: "bottom" },
+    ]
+    const [placement] = layoutDecouplingCapacitors(chip, pins)
+    expect(placement.position.y).toBeLessThan(-2)
+    expect(placement.rotation).toBe(0)
+  })
+
+  it("places a left-side cap to the left of the chip", () => {
+    const pins: PinInfo[] = [
+      { pinNumber: 9, net: "VCC", position: { x: -2, y: 0 }, side: "left" },
+    ]
+    const [placement] = layoutDecouplingCapacitors(chip, pins)
+    expect(placement.position.x).toBeLessThan(-2)
+    expect(placement.rotation).toBe(90)
+  })
+
+  it("places a right-side cap to the right of the chip", () => {
+    const pins: PinInfo[] = [
+      { pinNumber: 13, net: "VDD", position: { x: 2, y: 0 }, side: "right" },
+    ]
+    const [placement] = layoutDecouplingCapacitors(chip, pins)
+    expect(placement.position.x).toBeGreaterThan(2)
+    expect(placement.rotation).toBe(90)
+  })
+
+  it("respects chipToCapGap option", () => {
+    const pins: PinInfo[] = [
+      { pinNumber: 1, net: "VDD", position: { x: 0, y: 2 }, side: "top" },
+    ]
+    const gapSmall = layoutDecouplingCapacitors(chip, pins, {
+      chipToCapGap: 0.25,
+    })
+    const gapLarge = layoutDecouplingCapacitors(chip, pins, {
+      chipToCapGap: 1.0,
+    })
+    expect(gapLarge[0].position.y).toBeGreaterThan(gapSmall[0].position.y)
+  })
+
+  it("assigns unique cap IDs based on pin number", () => {
+    const pins: PinInfo[] = [
+      { pinNumber: 2, net: "VDD", position: { x: -1, y: 2 }, side: "top" },
+      { pinNumber: 6, net: "VDD", position: { x: 1, y: 2 }, side: "top" },
+    ]
+    const placements = layoutDecouplingCapacitors(chip, pins)
+    expect(placements[0].capId).toBe("C_2")
+    expect(placements[1].capId).toBe("C_6")
+  })
+
+  it("prevents overlapping caps on the same side", () => {
+    const spacing = 0.8
+    const pins: PinInfo[] = [
+      { pinNumber: 1, net: "VDD", position: { x: 0, y: 2 }, side: "top" },
+      { pinNumber: 2, net: "VCC", position: { x: 0.1, y: 2 }, side: "top" }, // almost same X
+    ]
+    const placements = layoutDecouplingCapacitors(chip, pins, {
+      capSpacing: spacing,
+    })
+    const dx = Math.abs(placements[1].position.x - placements[0].position.x)
+    expect(dx).toBeGreaterThanOrEqual(spacing - 1e-6)
+  })
+
+  it("handles mixed-side pins correctly", () => {
+    const pins: PinInfo[] = [
+      { pinNumber: 1, net: "VDD", position: { x: -1, y: 2 }, side: "top" },
+      { pinNumber: 5, net: "GND", position: { x: -2, y: -0.5 }, side: "left" },
+      { pinNumber: 9, net: "VCC", position: { x: 1, y: -2 }, side: "bottom" },
+      { pinNumber: 13, net: "VSS", position: { x: 2, y: 0.5 }, side: "right" },
+    ]
+    const placements = layoutDecouplingCapacitors(chip, pins)
+    expect(placements).toHaveLength(4)
+
+    const byPin = Object.fromEntries(placements.map((p) => [p.pinNumber, p]))
+
+    // top cap is above chip
+    expect(byPin[1].position.y).toBeGreaterThan(2)
+    // left cap is to the left
+    expect(byPin[5].position.x).toBeLessThan(-2)
+    // bottom cap is below chip
+    expect(byPin[9].position.y).toBeLessThan(-2)
+    // right cap is to the right
+    expect(byPin[13].position.x).toBeGreaterThan(2)
+  })
+})

--- a/lib/layouts/decoupling-capacitor-layout.test.ts
+++ b/lib/layouts/decoupling-capacitor-layout.test.ts
@@ -1,154 +1,258 @@
+/**
+ * Unit tests for decoupling-capacitor layout helpers.
+ *
+ * Run with:  npx vitest run lib/layouts/decoupling-capacitor-layout.test.ts
+ */
+
 import { describe, it, expect } from "vitest"
 import {
-  layoutDecouplingCapacitors,
-  filterDecouplingPins,
   isPowerNet,
-  type ComponentBounds,
+  filterDecouplingPins,
+  layoutDecouplingCapacitors,
+  POWER_NET_PATTERNS,
   type PinInfo,
 } from "./decoupling-capacitor-layout"
 
 // ---------------------------------------------------------------------------
 // isPowerNet
 // ---------------------------------------------------------------------------
+
 describe("isPowerNet", () => {
-  it("matches common power nets", () => {
-    expect(isPowerNet("VDD")).toBe(true)
-    expect(isPowerNet("VCC")).toBe(true)
-    expect(isPowerNet("GND")).toBe(true)
-    expect(isPowerNet("VSS")).toBe(true)
-    expect(isPowerNet("AVDD")).toBe(true)
-    expect(isPowerNet("DVDD")).toBe(true)
-    expect(isPowerNet("3V3")).toBe(true)
-    expect(isPowerNet("1V8")).toBe(true)
+  // Standard supply rails
+  it.each([
+    "VCC",
+    "vcc",
+    "VDD",
+    "vdd",
+    "VDD_3V3",
+    "VSS",
+    "vss",
+    "VBAT",
+    "V3V3",
+    "V5V",
+    "V1V8",
+    "VBUS",
+    "VSYS",
+    "VMAIN",
+    "VCORE",
+    "VIO",
+    "VREF",
+    "VANA",
+    "VDIG",
+  ])("returns true for supply rail '%s'", (name) => {
+    expect(isPowerNet(name)).toBe(true)
   })
 
-  it("does not match signal nets", () => {
-    expect(isPowerNet("CLK")).toBe(false)
-    expect(isPowerNet("MISO")).toBe(false)
-    expect(isPowerNet("GPIO0")).toBe(false)
-    expect(isPowerNet("TX")).toBe(false)
+  // Ground variants (standard)
+  it.each(["GND", "gnd"])("returns true for standard ground '%s'", (name) => {
+    expect(isPowerNet(name)).toBe(true)
+  })
+
+  // Ground variants — analogue, digital, power-ground (the gap flagged in review)
+  it.each([
+    "AGND",
+    "agnd",
+    "AGND_ISO",
+    "DGND",
+    "dgnd",
+    "PGND",
+    "pgnd",
+    "SGND",
+    "EGND",
+    "GNDD",
+    "GNDA",
+  ])(
+    "returns true for specialised ground rail '%s'",
+    (name) => {
+      expect(isPowerNet(name)).toBe(true)
+    },
+  )
+
+  // VSS variants
+  it.each(["AVSS", "avss", "DVSS", "dvss"])(
+    "returns true for VSS variant '%s'",
+    (name) => {
+      expect(isPowerNet(name)).toBe(true)
+    },
+  )
+
+  // Signal nets that should NOT match
+  it.each([
+    "SDA",
+    "SCL",
+    "MOSI",
+    "MISO",
+    "CS",
+    "INT",
+    "RST",
+    "LED",
+    "TX",
+    "RX",
+    "CLK",
+    "DATA",
+  ])("returns false for signal net '%s'", (name) => {
+    expect(isPowerNet(name)).toBe(false)
   })
 })
 
 // ---------------------------------------------------------------------------
 // filterDecouplingPins
 // ---------------------------------------------------------------------------
-describe("filterDecouplingPins", () => {
-  const pins: PinInfo[] = [
-    { pinNumber: 1, net: "VDD", position: { x: 0, y: 2 }, side: "top" },
-    { pinNumber: 2, net: "CLK", position: { x: 1, y: 2 }, side: "top" },
-    { pinNumber: 3, net: "GND", position: { x: 0, y: -2 }, side: "bottom" },
-    { pinNumber: 4, net: "MISO", position: { x: -2, y: 0 }, side: "left" },
-  ]
 
-  it("returns only power / ground pins", () => {
-    const filtered = filterDecouplingPins(pins)
-    expect(filtered).toHaveLength(2)
-    expect(filtered.map((p) => p.net)).toEqual(["VDD", "GND"])
+describe("filterDecouplingPins", () => {
+  const makePins = (nets: string[]): PinInfo[] =>
+    nets.map((net, i) => ({
+      pinNumber: i + 1,
+      net,
+      position: { x: 0, y: 0 },
+      side: "top" as const,
+    }))
+
+  it("keeps only power-net pins", () => {
+    const pins = makePins(["VDD", "SDA", "GND", "CLK", "AGND", "DGND"])
+    const result = filterDecouplingPins(pins)
+    expect(result.map((p) => p.net)).toEqual(["VDD", "GND", "AGND", "DGND"])
+  })
+
+  it("returns empty array when no power nets", () => {
+    const pins = makePins(["SDA", "SCL", "MOSI", "MISO"])
+    expect(filterDecouplingPins(pins)).toHaveLength(0)
   })
 })
 
 // ---------------------------------------------------------------------------
-// layoutDecouplingCapacitors — basic geometry
+// layoutDecouplingCapacitors
 // ---------------------------------------------------------------------------
+
 describe("layoutDecouplingCapacitors", () => {
-  const chip: ComponentBounds = {
-    centre: { x: 0, y: 0 },
-    width: 4, // ±2 mm from centre
-    height: 4,
-  }
+  it("places a single top-side decap outward from the IC pin", () => {
+    const map = new Map<string, PinInfo>([
+      [
+        "C1",
+        {
+          pinNumber: 1,
+          net: "VDD",
+          position: { x: 5, y: 10 },
+          side: "top",
+        },
+      ],
+    ])
 
-  it("places a top-side cap above the chip", () => {
-    const pins: PinInfo[] = [
-      { pinNumber: 1, net: "VDD", position: { x: 0, y: 2 }, side: "top" },
-    ]
-    const [placement] = layoutDecouplingCapacitors(chip, pins)
-    expect(placement.position.y).toBeGreaterThan(2) // above chip edge
-    expect(placement.rotation).toBe(0)
+    const [p] = layoutDecouplingCapacitors(map, { clearance: 0.5 })
+    expect(p.componentId).toBe("C1")
+    // Should be placed 0.5 mm above the pin (positive Y = outward from top).
+    expect(p.position.x).toBeCloseTo(5)
+    expect(p.position.y).toBeCloseTo(10.5)
+    expect(p.rotation).toBe(90)
+    expect(p.side).toBe("top")
+    expect(p.net).toBe("VDD")
   })
 
-  it("places a bottom-side cap below the chip", () => {
-    const pins: PinInfo[] = [
-      { pinNumber: 5, net: "GND", position: { x: 0, y: -2 }, side: "bottom" },
-    ]
-    const [placement] = layoutDecouplingCapacitors(chip, pins)
-    expect(placement.position.y).toBeLessThan(-2)
-    expect(placement.rotation).toBe(0)
+  it("places a bottom-side decap outward (negative Y)", () => {
+    const map = new Map<string, PinInfo>([
+      [
+        "C2",
+        {
+          pinNumber: 2,
+          net: "GND",
+          position: { x: 3, y: -8 },
+          side: "bottom",
+        },
+      ],
+    ])
+
+    const [p] = layoutDecouplingCapacitors(map, { clearance: 0.5 })
+    expect(p.position.x).toBeCloseTo(3)
+    expect(p.position.y).toBeCloseTo(-8.5)
+    expect(p.rotation).toBe(90)
   })
 
-  it("places a left-side cap to the left of the chip", () => {
-    const pins: PinInfo[] = [
-      { pinNumber: 9, net: "VCC", position: { x: -2, y: 0 }, side: "left" },
-    ]
-    const [placement] = layoutDecouplingCapacitors(chip, pins)
-    expect(placement.position.x).toBeLessThan(-2)
-    expect(placement.rotation).toBe(90)
+  it("places a right-side decap outward (positive X)", () => {
+    const map = new Map<string, PinInfo>([
+      [
+        "C3",
+        {
+          pinNumber: 3,
+          net: "VCC",
+          position: { x: 7, y: 2 },
+          side: "right",
+        },
+      ],
+    ])
+
+    const [p] = layoutDecouplingCapacitors(map, { clearance: 1.0 })
+    expect(p.position.x).toBeCloseTo(8)
+    expect(p.position.y).toBeCloseTo(2)
+    expect(p.rotation).toBe(0)
   })
 
-  it("places a right-side cap to the right of the chip", () => {
-    const pins: PinInfo[] = [
-      { pinNumber: 13, net: "VDD", position: { x: 2, y: 0 }, side: "right" },
-    ]
-    const [placement] = layoutDecouplingCapacitors(chip, pins)
-    expect(placement.position.x).toBeGreaterThan(2)
-    expect(placement.rotation).toBe(90)
+  it("places a left-side decap outward (negative X)", () => {
+    const map = new Map<string, PinInfo>([
+      [
+        "C4",
+        {
+          pinNumber: 4,
+          net: "AGND",
+          position: { x: -5, y: 1 },
+          side: "left",
+        },
+      ],
+    ])
+
+    const [p] = layoutDecouplingCapacitors(map, { clearance: 0.5 })
+    expect(p.position.x).toBeCloseTo(-5.5)
+    expect(p.position.y).toBeCloseTo(1)
+    expect(p.rotation).toBe(0)
   })
 
-  it("respects chipToCapGap option", () => {
-    const pins: PinInfo[] = [
-      { pinNumber: 1, net: "VDD", position: { x: 0, y: 2 }, side: "top" },
-    ]
-    const gapSmall = layoutDecouplingCapacitors(chip, pins, {
-      chipToCapGap: 0.25,
-    })
-    const gapLarge = layoutDecouplingCapacitors(chip, pins, {
-      chipToCapGap: 1.0,
-    })
-    expect(gapLarge[0].position.y).toBeGreaterThan(gapSmall[0].position.y)
+  it("stacks multiple decaps on the same side without overlap", () => {
+    const map = new Map<string, PinInfo>([
+      [
+        "C5",
+        {
+          pinNumber: 5,
+          net: "DGND",
+          position: { x: 0, y: 5 },
+          side: "top",
+        },
+      ],
+      [
+        "C6",
+        {
+          pinNumber: 6,
+          net: "PGND",
+          position: { x: 0, y: 5 },
+          side: "top",
+        },
+      ],
+    ])
+
+    const ps = layoutDecouplingCapacitors(map, { clearance: 0.5, step: 1.0 })
+    expect(ps).toHaveLength(2)
+    // First row: 0.5 mm out; second row: 1.5 mm out.
+    const ys = ps.map((p) => p.position.y).sort((a, b) => a - b)
+    expect(ys[0]).toBeCloseTo(5.5)
+    expect(ys[1]).toBeCloseTo(6.5)
   })
 
-  it("assigns unique cap IDs based on pin number", () => {
-    const pins: PinInfo[] = [
-      { pinNumber: 2, net: "VDD", position: { x: -1, y: 2 }, side: "top" },
-      { pinNumber: 6, net: "VDD", position: { x: 1, y: 2 }, side: "top" },
-    ]
-    const placements = layoutDecouplingCapacitors(chip, pins)
-    expect(placements[0].capId).toBe("C_2")
-    expect(placements[1].capId).toBe("C_6")
+  it("returns an empty array for an empty map", () => {
+    expect(layoutDecouplingCapacitors(new Map())).toHaveLength(0)
   })
 
-  it("prevents overlapping caps on the same side", () => {
-    const spacing = 0.8
-    const pins: PinInfo[] = [
-      { pinNumber: 1, net: "VDD", position: { x: 0, y: 2 }, side: "top" },
-      { pinNumber: 2, net: "VCC", position: { x: 0.1, y: 2 }, side: "top" }, // almost same X
-    ]
-    const placements = layoutDecouplingCapacitors(chip, pins, {
-      capSpacing: spacing,
-    })
-    const dx = Math.abs(placements[1].position.x - placements[0].position.x)
-    expect(dx).toBeGreaterThanOrEqual(spacing - 1e-6)
-  })
-
-  it("handles mixed-side pins correctly", () => {
-    const pins: PinInfo[] = [
-      { pinNumber: 1, net: "VDD", position: { x: -1, y: 2 }, side: "top" },
-      { pinNumber: 5, net: "GND", position: { x: -2, y: -0.5 }, side: "left" },
-      { pinNumber: 9, net: "VCC", position: { x: 1, y: -2 }, side: "bottom" },
-      { pinNumber: 13, net: "VSS", position: { x: 2, y: 0.5 }, side: "right" },
-    ]
-    const placements = layoutDecouplingCapacitors(chip, pins)
-    expect(placements).toHaveLength(4)
-
-    const byPin = Object.fromEntries(placements.map((p) => [p.pinNumber, p]))
-
-    // top cap is above chip
-    expect(byPin[1].position.y).toBeGreaterThan(2)
-    // left cap is to the left
-    expect(byPin[5].position.x).toBeLessThan(-2)
-    // bottom cap is below chip
-    expect(byPin[9].position.y).toBeLessThan(-2)
-    // right cap is to the right
-    expect(byPin[13].position.x).toBeGreaterThan(2)
+  it("handles AGND as a valid net name (regression for review comment)", () => {
+    const map = new Map<string, PinInfo>([
+      [
+        "C7",
+        {
+          pinNumber: 7,
+          net: "AGND",
+          position: { x: 1, y: 2 },
+          side: "bottom",
+        },
+      ],
+    ])
+    const [p] = layoutDecouplingCapacitors(map)
+    expect(p.net).toBe("AGND")
+    expect(p.componentId).toBe("C7")
   })
 })

--- a/lib/layouts/decoupling-capacitor-layout.ts
+++ b/lib/layouts/decoupling-capacitor-layout.ts
@@ -1,0 +1,225 @@
+/**
+ * Specialized Layout for Decoupling Capacitors
+ *
+ * This module implements a layout strategy that places decoupling capacitors
+ * as close as possible to their associated power pins on a chip, following
+ * best-practice PCB layout guidelines (each cap adjacent to its pin, on the
+ * same side as the pin when possible, oriented radially outward from the IC).
+ *
+ * Issue: https://github.com/tscircuit/matchpack/issues/15
+ */
+
+export interface Point {
+  x: number
+  y: number
+}
+
+export interface PinInfo {
+  /** Pin number on the chip */
+  pinNumber: number
+  /** Net name (e.g. "VDD", "VCC", "GND") */
+  net: string
+  /** Absolute position of the pin centre */
+  position: Point
+  /** Which side of the chip this pin is on */
+  side: "top" | "bottom" | "left" | "right"
+}
+
+export interface ComponentBounds {
+  /** Centre of the chip */
+  centre: Point
+  /** Total width of the chip body */
+  width: number
+  /** Total height of the chip body */
+  height: number
+}
+
+export interface CapacitorPlacement {
+  /** The capacitor reference designator / id */
+  capId: string
+  /** The power pin this cap is decoupling */
+  pinNumber: number
+  /** Suggested placement position (centre of the capacitor) */
+  position: Point
+  /** Rotation in degrees (0 = pads left-right, 90 = pads top-bottom) */
+  rotation: number
+}
+
+export interface DecouplingCapacitorLayoutOptions {
+  /**
+   * Gap between the chip body edge and the nearest pad of the capacitor.
+   * Default: 0.5 mm
+   */
+  chipToCapGap?: number
+  /**
+   * Centre-to-centre spacing between adjacent capacitors placed on the same
+   * side of the chip.
+   * Default: 1.0 mm
+   */
+  capSpacing?: number
+  /**
+   * Capacitor body length (long axis).  Matches a standard 0402: 1.0 mm.
+   */
+  capLength?: number
+  /**
+   * Capacitor body width (short axis).  Matches a standard 0402: 0.5 mm.
+   */
+  capWidth?: number
+}
+
+/** Internal grouping used during layout */
+interface SideGroup {
+  side: "top" | "bottom" | "left" | "right"
+  pins: PinInfo[]
+}
+
+/**
+ * Given a set of power / decoupling pins on a chip and one capacitor per pin,
+ * compute the best-fit placement for every capacitor so that:
+ *
+ *  1. Each cap is placed on the same side of the chip as its associated pin.
+ *  2. Each cap is as close to its pin as the gap constraint allows.
+ *  3. Caps on the same side are arranged in pin order so they don't overlap.
+ *  4. The cap is oriented so its pads are aligned with the power trace direction
+ *     (parallel to the chip edge → perpendicular to the current flow).
+ */
+export function layoutDecouplingCapacitors(
+  chip: ComponentBounds,
+  pins: PinInfo[],
+  options: DecouplingCapacitorLayoutOptions = {},
+): CapacitorPlacement[] {
+  const {
+    chipToCapGap = 0.5,
+    capSpacing = 1.0,
+    capLength = 1.0,
+    capWidth = 0.5,
+  } = options
+
+  // Half-extents of the chip body
+  const halfW = chip.width / 2
+  const halfH = chip.height / 2
+
+  // Group pins by side
+  const sides: Record<string, PinInfo[]> = {
+    top: [],
+    bottom: [],
+    left: [],
+    right: [],
+  }
+  for (const pin of pins) {
+    sides[pin.side].push(pin)
+  }
+
+  const placements: CapacitorPlacement[] = []
+
+  for (const side of ["top", "bottom", "left", "right"] as const) {
+    const sidePins = sides[side]
+    if (sidePins.length === 0) continue
+
+    // Sort pins by their position along the side axis so caps don't overlap
+    const isHorizontalSide = side === "top" || side === "bottom"
+    sidePins.sort((a, b) =>
+      isHorizontalSide
+        ? a.position.x - b.position.x
+        : a.position.y - b.position.y,
+    )
+
+    for (let i = 0; i < sidePins.length; i++) {
+      const pin = sidePins[i]
+      let capX: number
+      let capY: number
+      let rotation: number
+
+      // Distance from chip centre to the outer edge of the chip body on this side,
+      // plus the gap, plus half the cap body (so the cap centre lands correctly).
+      const halfCapMajor = capLength / 2
+
+      switch (side) {
+        case "top":
+          // Cap sits above the chip, pads are left-right (rotation=0) so the
+          // decoupling current flows straight into the power plane.
+          capX = pin.position.x
+          capY = chip.centre.y + halfH + chipToCapGap + halfCapMajor
+          rotation = 0
+          break
+
+        case "bottom":
+          capX = pin.position.x
+          capY = chip.centre.y - halfH - chipToCapGap - halfCapMajor
+          rotation = 0
+          break
+
+        case "left":
+          // Cap sits to the left of the chip, pads are top-bottom (rotation=90).
+          capX = chip.centre.x - halfW - chipToCapGap - halfCapMajor
+          capY = pin.position.y
+          rotation = 90
+          break
+
+        case "right":
+          capX = chip.centre.x + halfW + chipToCapGap + halfCapMajor
+          capY = pin.position.y
+          rotation = 90
+          break
+      }
+
+      // Resolve overlaps: if two caps on the same side would be closer than
+      // capSpacing, nudge later ones outward along the side axis.
+      if (i > 0) {
+        const prev = placements[placements.length - 1]
+        if (isHorizontalSide) {
+          const minX = prev.position.x + capSpacing
+          if (capX < minX) capX = minX
+        } else {
+          const minY = prev.position.y + capSpacing
+          if (capY < minY) capY = minY
+        }
+      }
+
+      placements.push({
+        capId: `C_${pin.pinNumber}`,
+        pinNumber: pin.pinNumber,
+        position: { x: capX, y: capY },
+        rotation,
+      })
+    }
+  }
+
+  return placements
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: detect which pins on a chip are power/ground and need decoupling
+// ---------------------------------------------------------------------------
+
+const POWER_NET_PATTERNS = [
+  /^vdd/i,
+  /^vcc/i,
+  /^vss/i,
+  /^gnd/i,
+  /^pwr/i,
+  /^power/i,
+  /^avdd/i,
+  /^dvdd/i,
+  /^iovdd/i,
+  /^vcca/i,
+  /^vccio/i,
+  /^3v3/i,
+  /^1v8/i,
+  /^5v/i,
+]
+
+/**
+ * Returns true if the given net name looks like a power/ground rail that
+ * typically requires a decoupling capacitor.
+ */
+export function isPowerNet(netName: string): boolean {
+  return POWER_NET_PATTERNS.some((re) => re.test(netName))
+}
+
+/**
+ * Filter a full pin list down to only those that need decoupling capacitors.
+ */
+export function filterDecouplingPins(pins: PinInfo[]): PinInfo[] {
+  return pins.filter((p) => isPowerNet(p.net))
+}

--- a/lib/layouts/decoupling-capacitor-layout.ts
+++ b/lib/layouts/decoupling-capacitor-layout.ts
@@ -1,132 +1,148 @@
 /**
  * Specialized layout algorithm for decoupling capacitors.
  *
- * Places each decap adjacent to the IC power/ground pin on the same net,
- * choosing the outward direction from the IC edge nearest that pin.
+ * Goal: place each decoupling capacitor adjacent to the IC power/ground pin
+ * it is associated with, on the same side of the IC as that pin.
  */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Point {
+  x: number
+  y: number
+}
 
 export type Side = "top" | "bottom" | "left" | "right"
 
+/**
+ * Information about an IC pin that a decoupling capacitor is associated with.
+ */
 export interface PinInfo {
-  /** Unique pin identifier (e.g. pin number 1-based or hashed) */
+  /** Numeric or positional identifier used to sort/cluster placements */
   pinNumber: number
-  /** Net name this pin belongs to */
+  /** Power/ground net name */
   net: string
-  /** Absolute position of the IC power pin (mm) */
-  position: { x: number; y: number }
-  /** Which side of the IC package this pin is on */
+  /** Physical position of the pin on the PCB */
+  position: Point
+  /** Which side of the IC the pin is on */
   side: Side
 }
 
-export interface DecapPlacement {
-  /** source_component_id of the decoupling capacitor */
-  componentId: string
-  /** Recommended centre position (mm) */
-  position: { x: number; y: number }
-  /** Recommended rotation in degrees */
-  rotation: number
-  /** Side of the IC this cap is placed on */
-  side: Side
-  /** The net this cap decouples */
-  net: string
+/**
+ * Input describing a single decoupling capacitor and where it should be
+ * placed relative to its associated IC power pin.
+ */
+export interface DecouplingCapPlacement {
+  /** Unique identifier for the capacitor (source_component_id) */
+  capacitorId: string
+  /** Resolved information about the associated IC power pin */
+  pinInfo: PinInfo
 }
 
-export interface DecapLayoutOptions {
-  /** Distance from the IC pin to the near edge of the decap (mm). Default 0.5 */
-  clearance?: number
-  /** Step between adjacent decaps on the same side (mm). Default 1.0 */
-  step?: number
+/**
+ * Result of running the layout algorithm for one capacitor.
+ */
+export interface PlacedDecouplingCap {
+  capacitorId: string
+  position: Point
+  rotation: number // degrees
+  side: Side
 }
 
 // ---------------------------------------------------------------------------
-// Power-net detection helpers
+// Power-net detection
 // ---------------------------------------------------------------------------
 
 /**
- * Patterns that identify a net name as a power / ground rail.
- * Includes common analogue (AGND/AVSS), digital (DGND/DVSS), and
- * power-ground (PGND) variants so that `filterDecouplingPins` works
- * correctly for mixed-signal and power-supply designs.
+ * Patterns that identify power/ground net names.
+ *
+ * Extended to cover common variants: AGND, DGND, PGND, AVSS, DVSS, etc.
  */
 export const POWER_NET_PATTERNS: RegExp[] = [
-  // Supply rails
   /^vcc/i,
+  /^avcc/i,
+  /^dvcc/i,
   /^vdd/i,
+  /^avdd/i,
+  /^dvdd/i,
   /^vss/i,
   /^avss/i,
   /^dvss/i,
-  /^vbat/i,
-  /^v3v3/i,
-  /^v5v/i,
-  /^v1v8/i,
-  /^v\d+v\d*/i,
-  /^pwr/i,
-  /^power/i,
-  /^vbus/i,
-  /^vsys/i,
-  /^vmain/i,
-  /^vcore/i,
-  /^vio/i,
-  /^vref/i,
-  /^vana/i,
-  /^vdig/i,
-  // Ground rails — explicit analogue / digital / power-ground variants
   /^gnd/i,
   /^agnd/i,
   /^dgnd/i,
   /^pgnd/i,
-  /^sgnd/i,
-  /^egnd/i,
-  /^gndd/i,
-  /^gnda/i,
+  /^pwr/i,
+  /^power/i,
+  /^vbat/i,
+  /^v3v3/i,
+  /^v5v/i,
+  /^v1v8/i,
+  /^vcca/i,
+  /^vccd/i,
+  /^vcore/i,
+  /^vio/i,
 ]
 
 /**
- * Returns `true` when `netName` matches any known power/ground pattern.
+ * Returns true if the given net name looks like a power or ground rail.
  */
 export function isPowerNet(netName: string): boolean {
-  return POWER_NET_PATTERNS.some((re) => re.test(netName))
+  return POWER_NET_PATTERNS.some((pattern) => pattern.test(netName))
 }
 
 /**
- * Filters `pins` to those whose net names look like power / ground rails.
+ * From a list of (netName, pinNumber) pairs, keep only the ones that are
+ * power/ground nets.
  */
-export function filterDecouplingPins(pins: PinInfo[]): PinInfo[] {
+export function filterDecouplingPins(
+  pins: Array<{ net: string; pinNumber: number; position: Point; side: Side }>,
+): Array<{ net: string; pinNumber: number; position: Point; side: Side }> {
   return pins.filter((p) => isPowerNet(p.net))
 }
 
 // ---------------------------------------------------------------------------
-// Layout helpers
+// Placement helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Returns the outward unit vector for a given IC side.
- */
-function sideVector(side: Side): { dx: number; dy: number } {
-  switch (side) {
-    case "top":
-      return { dx: 0, dy: 1 }
-    case "bottom":
-      return { dx: 0, dy: -1 }
-    case "left":
-      return { dx: -1, dy: 0 }
-    case "right":
-      return { dx: 1, dy: 0 }
-  }
+/** How far from the IC pin the capacitor body centre should sit (mm) */
+const DEFAULT_CLEARANCE_MM = 0.8
+
+/** Map from side to the outward unit vector */
+const SIDE_NORMAL: Record<Side, Point> = {
+  top: { x: 0, y: 1 },
+  bottom: { x: 0, y: -1 },
+  left: { x: -1, y: 0 },
+  right: { x: 1, y: 0 },
+}
+
+/** Rotation (degrees) to give a 0402/0603 capacitor on each side so its
+ *  pads align with the power and ground rails running away from the IC. */
+const SIDE_ROTATION: Record<Side, number> = {
+  top: 0,
+  bottom: 0,
+  left: 90,
+  right: 90,
 }
 
 /**
- * Returns the rotation (degrees) for a 0402/0603 decap placed on `side`.
- * Pads run parallel to the IC edge, so the component axis is perpendicular.
+ * Compute the placement (position + rotation) for a single decoupling
+ * capacitor given its associated IC power pin.
  */
-function rotationForSide(side: Side): number {
-  switch (side) {
-    case "top":
-    case "bottom":
-      return 90 // pads on left/right → component body horizontal → 90°
-    case "left":
-    case "right":
-      return 0 // pads on top/bottom → component body vertical → 0°
+export function computeCapPlacement(
+  pinInfo: PinInfo,
+  clearanceMm: number = DEFAULT_CLEARANCE_MM,
+): { position: Point; rotation: number; side: Side } {
+  const normal = SIDE_NORMAL[pinInfo.side]
+  return {
+    position: {
+      x: pinInfo.position.x + normal.x * clearanceMm,
+      y: pinInfo.position.y + normal.y * clearanceMm,
+    },
+    rotation: SIDE_ROTATION[pinInfo.side],
+    side: pinInfo.side,
   }
 }
 
@@ -135,69 +151,68 @@ function rotationForSide(side: Side): number {
 // ---------------------------------------------------------------------------
 
 /**
- * Computes placement (position + rotation) for each decoupling capacitor
- * described in `decapMap`.
+ * Run the decoupling-capacitor layout algorithm.
  *
- * @param decapMap  Map from `source_component_id` → `PinInfo` for each decap.
- * @param options   Optional tuning (clearance, step).
- * @returns         Array of `DecapPlacement` objects, one per entry in the map.
+ * For each capacitor in `placements`, computes a physical (x, y, rotation)
+ * that places it just outside the IC boundary adjacent to its power pin.
+ *
+ * When multiple capacitors share the same pin/net, they are spread along the
+ * axis perpendicular to the outward normal so they do not overlap.
  */
 export function layoutDecouplingCapacitors(
-  decapMap: Map<string, PinInfo>,
-  options: DecapLayoutOptions = {},
-): DecapPlacement[] {
-  const clearance = options.clearance ?? 0.5
-  const step = options.step ?? 1.0
+  placements: DecouplingCapPlacement[],
+  options: {
+    clearanceMm?: number
+    spacingMm?: number
+  } = {},
+): PlacedDecouplingCap[] {
+  const clearance = options.clearanceMm ?? DEFAULT_CLEARANCE_MM
+  const spacing = options.spacingMm ?? 0.6
 
-  // Group decaps by side so we can spread them out without overlap.
-  const bySide = new Map<Side, Array<{ id: string; pin: PinInfo }>>()
-  for (const [id, pin] of decapMap) {
-    const arr = bySide.get(pin.side) ?? []
-    arr.push({ id, pin })
-    bySide.set(pin.side, arr)
+  // Group capacitors by (side, pinNumber) so we can spread them out.
+  const groups = new Map<string, DecouplingCapPlacement[]>()
+  for (const p of placements) {
+    const key = `${p.pinInfo.side}::${p.pinInfo.pinNumber}`
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(p)
   }
 
-  const placements: DecapPlacement[] = []
+  const results: PlacedDecouplingCap[] = []
 
-  for (const [side, caps] of bySide) {
-    const { dx, dy } = sideVector(side)
-    const rotation = rotationForSide(side)
-    const isVertical = side === "left" || side === "right"
-
-    // Sort along the IC edge (tangential axis) so identical-net caps end up
-    // neatly stacked before spreading to a second row.
-    caps.sort((a, b) => {
-      const ta = isVertical ? a.pin.position.y : a.pin.position.x
-      const tb = isVertical ? b.pin.position.y : b.pin.position.x
-      return ta - tb
-    })
-
-    // Track how many caps we've placed at each tangential slot to allow a
-    // second row when multiple caps share a pin position.
-    const slotDepth = new Map<string, number>()
-
-    for (const { id, pin } of caps) {
-      const tangential = isVertical ? pin.position.y : pin.position.x
-      const slotKey = tangential.toFixed(3)
-      const depth = slotDepth.get(slotKey) ?? 0
-      slotDepth.set(slotKey, depth + 1)
-
-      // Normal (outward) offset: clearance + extra rows push further out.
-      const normalOffset = clearance + depth * step
-
-      // Tangential position stays aligned with the IC pin.
-      const cx = pin.position.x + dx * normalOffset
-      const cy = pin.position.y + dy * normalOffset
-
-      placements.push({
-        componentId: id,
-        position: { x: cx, y: cy },
-        rotation,
-        side,
-        net: pin.net,
+  for (const group of groups.values()) {
+    const count = group.length
+    // Spread caps symmetrically around the base position along the tangent axis.
+    group.forEach((cap, i) => {
+      const base = computeCapPlacement(cap.pinInfo, clearance)
+      const tangent = getTangent(cap.pinInfo.side)
+      const offset = (i - (count - 1) / 2) * spacing
+      results.push({
+        capacitorId: cap.capacitorId,
+        position: {
+          x: base.position.x + tangent.x * offset,
+          y: base.position.y + tangent.y * offset,
+        },
+        rotation: base.rotation,
+        side: base.side,
       })
-    }
+    })
   }
 
-  return placements
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Returns the unit vector tangent to the given side (perpendicular to normal). */
+function getTangent(side: Side): Point {
+  switch (side) {
+    case "top":
+    case "bottom":
+      return { x: 1, y: 0 }
+    case "left":
+    case "right":
+      return { x: 0, y: 1 }
+  }
 }

--- a/lib/layouts/decoupling-capacitor-layout.ts
+++ b/lib/layouts/decoupling-capacitor-layout.ts
@@ -1,225 +1,203 @@
 /**
- * Specialized Layout for Decoupling Capacitors
+ * Specialized layout algorithm for decoupling capacitors.
  *
- * This module implements a layout strategy that places decoupling capacitors
- * as close as possible to their associated power pins on a chip, following
- * best-practice PCB layout guidelines (each cap adjacent to its pin, on the
- * same side as the pin when possible, oriented radially outward from the IC).
- *
- * Issue: https://github.com/tscircuit/matchpack/issues/15
+ * Places each decap adjacent to the IC power/ground pin on the same net,
+ * choosing the outward direction from the IC edge nearest that pin.
  */
 
-export interface Point {
-  x: number
-  y: number
-}
+export type Side = "top" | "bottom" | "left" | "right"
 
 export interface PinInfo {
-  /** Pin number on the chip */
+  /** Unique pin identifier (e.g. pin number 1-based or hashed) */
   pinNumber: number
-  /** Net name (e.g. "VDD", "VCC", "GND") */
+  /** Net name this pin belongs to */
   net: string
-  /** Absolute position of the pin centre */
-  position: Point
-  /** Which side of the chip this pin is on */
-  side: "top" | "bottom" | "left" | "right"
+  /** Absolute position of the IC power pin (mm) */
+  position: { x: number; y: number }
+  /** Which side of the IC package this pin is on */
+  side: Side
 }
 
-export interface ComponentBounds {
-  /** Centre of the chip */
-  centre: Point
-  /** Total width of the chip body */
-  width: number
-  /** Total height of the chip body */
-  height: number
-}
-
-export interface CapacitorPlacement {
-  /** The capacitor reference designator / id */
-  capId: string
-  /** The power pin this cap is decoupling */
-  pinNumber: number
-  /** Suggested placement position (centre of the capacitor) */
-  position: Point
-  /** Rotation in degrees (0 = pads left-right, 90 = pads top-bottom) */
+export interface DecapPlacement {
+  /** source_component_id of the decoupling capacitor */
+  componentId: string
+  /** Recommended centre position (mm) */
+  position: { x: number; y: number }
+  /** Recommended rotation in degrees */
   rotation: number
+  /** Side of the IC this cap is placed on */
+  side: Side
+  /** The net this cap decouples */
+  net: string
 }
 
-export interface DecouplingCapacitorLayoutOptions {
-  /**
-   * Gap between the chip body edge and the nearest pad of the capacitor.
-   * Default: 0.5 mm
-   */
-  chipToCapGap?: number
-  /**
-   * Centre-to-centre spacing between adjacent capacitors placed on the same
-   * side of the chip.
-   * Default: 1.0 mm
-   */
-  capSpacing?: number
-  /**
-   * Capacitor body length (long axis).  Matches a standard 0402: 1.0 mm.
-   */
-  capLength?: number
-  /**
-   * Capacitor body width (short axis).  Matches a standard 0402: 0.5 mm.
-   */
-  capWidth?: number
+export interface DecapLayoutOptions {
+  /** Distance from the IC pin to the near edge of the decap (mm). Default 0.5 */
+  clearance?: number
+  /** Step between adjacent decaps on the same side (mm). Default 1.0 */
+  step?: number
 }
 
-/** Internal grouping used during layout */
-interface SideGroup {
-  side: "top" | "bottom" | "left" | "right"
-  pins: PinInfo[]
-}
+// ---------------------------------------------------------------------------
+// Power-net detection helpers
+// ---------------------------------------------------------------------------
 
 /**
- * Given a set of power / decoupling pins on a chip and one capacitor per pin,
- * compute the best-fit placement for every capacitor so that:
- *
- *  1. Each cap is placed on the same side of the chip as its associated pin.
- *  2. Each cap is as close to its pin as the gap constraint allows.
- *  3. Caps on the same side are arranged in pin order so they don't overlap.
- *  4. The cap is oriented so its pads are aligned with the power trace direction
- *     (parallel to the chip edge → perpendicular to the current flow).
+ * Patterns that identify a net name as a power / ground rail.
+ * Includes common analogue (AGND/AVSS), digital (DGND/DVSS), and
+ * power-ground (PGND) variants so that `filterDecouplingPins` works
+ * correctly for mixed-signal and power-supply designs.
  */
-export function layoutDecouplingCapacitors(
-  chip: ComponentBounds,
-  pins: PinInfo[],
-  options: DecouplingCapacitorLayoutOptions = {},
-): CapacitorPlacement[] {
-  const {
-    chipToCapGap = 0.5,
-    capSpacing = 1.0,
-    capLength = 1.0,
-    capWidth = 0.5,
-  } = options
-
-  // Half-extents of the chip body
-  const halfW = chip.width / 2
-  const halfH = chip.height / 2
-
-  // Group pins by side
-  const sides: Record<string, PinInfo[]> = {
-    top: [],
-    bottom: [],
-    left: [],
-    right: [],
-  }
-  for (const pin of pins) {
-    sides[pin.side].push(pin)
-  }
-
-  const placements: CapacitorPlacement[] = []
-
-  for (const side of ["top", "bottom", "left", "right"] as const) {
-    const sidePins = sides[side]
-    if (sidePins.length === 0) continue
-
-    // Sort pins by their position along the side axis so caps don't overlap
-    const isHorizontalSide = side === "top" || side === "bottom"
-    sidePins.sort((a, b) =>
-      isHorizontalSide
-        ? a.position.x - b.position.x
-        : a.position.y - b.position.y,
-    )
-
-    for (let i = 0; i < sidePins.length; i++) {
-      const pin = sidePins[i]
-      let capX: number
-      let capY: number
-      let rotation: number
-
-      // Distance from chip centre to the outer edge of the chip body on this side,
-      // plus the gap, plus half the cap body (so the cap centre lands correctly).
-      const halfCapMajor = capLength / 2
-
-      switch (side) {
-        case "top":
-          // Cap sits above the chip, pads are left-right (rotation=0) so the
-          // decoupling current flows straight into the power plane.
-          capX = pin.position.x
-          capY = chip.centre.y + halfH + chipToCapGap + halfCapMajor
-          rotation = 0
-          break
-
-        case "bottom":
-          capX = pin.position.x
-          capY = chip.centre.y - halfH - chipToCapGap - halfCapMajor
-          rotation = 0
-          break
-
-        case "left":
-          // Cap sits to the left of the chip, pads are top-bottom (rotation=90).
-          capX = chip.centre.x - halfW - chipToCapGap - halfCapMajor
-          capY = pin.position.y
-          rotation = 90
-          break
-
-        case "right":
-          capX = chip.centre.x + halfW + chipToCapGap + halfCapMajor
-          capY = pin.position.y
-          rotation = 90
-          break
-      }
-
-      // Resolve overlaps: if two caps on the same side would be closer than
-      // capSpacing, nudge later ones outward along the side axis.
-      if (i > 0) {
-        const prev = placements[placements.length - 1]
-        if (isHorizontalSide) {
-          const minX = prev.position.x + capSpacing
-          if (capX < minX) capX = minX
-        } else {
-          const minY = prev.position.y + capSpacing
-          if (capY < minY) capY = minY
-        }
-      }
-
-      placements.push({
-        capId: `C_${pin.pinNumber}`,
-        pinNumber: pin.pinNumber,
-        position: { x: capX, y: capY },
-        rotation,
-      })
-    }
-  }
-
-  return placements
-}
-
-// ---------------------------------------------------------------------------
-// Convenience: detect which pins on a chip are power/ground and need decoupling
-// ---------------------------------------------------------------------------
-
-const POWER_NET_PATTERNS = [
-  /^vdd/i,
+export const POWER_NET_PATTERNS: RegExp[] = [
+  // Supply rails
   /^vcc/i,
+  /^vdd/i,
   /^vss/i,
-  /^gnd/i,
+  /^avss/i,
+  /^dvss/i,
+  /^vbat/i,
+  /^v3v3/i,
+  /^v5v/i,
+  /^v1v8/i,
+  /^v\d+v\d*/i,
   /^pwr/i,
   /^power/i,
-  /^avdd/i,
-  /^dvdd/i,
-  /^iovdd/i,
-  /^vcca/i,
-  /^vccio/i,
-  /^3v3/i,
-  /^1v8/i,
-  /^5v/i,
+  /^vbus/i,
+  /^vsys/i,
+  /^vmain/i,
+  /^vcore/i,
+  /^vio/i,
+  /^vref/i,
+  /^vana/i,
+  /^vdig/i,
+  // Ground rails — explicit analogue / digital / power-ground variants
+  /^gnd/i,
+  /^agnd/i,
+  /^dgnd/i,
+  /^pgnd/i,
+  /^sgnd/i,
+  /^egnd/i,
+  /^gndd/i,
+  /^gnda/i,
 ]
 
 /**
- * Returns true if the given net name looks like a power/ground rail that
- * typically requires a decoupling capacitor.
+ * Returns `true` when `netName` matches any known power/ground pattern.
  */
 export function isPowerNet(netName: string): boolean {
   return POWER_NET_PATTERNS.some((re) => re.test(netName))
 }
 
 /**
- * Filter a full pin list down to only those that need decoupling capacitors.
+ * Filters `pins` to those whose net names look like power / ground rails.
  */
 export function filterDecouplingPins(pins: PinInfo[]): PinInfo[] {
   return pins.filter((p) => isPowerNet(p.net))
+}
+
+// ---------------------------------------------------------------------------
+// Layout helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the outward unit vector for a given IC side.
+ */
+function sideVector(side: Side): { dx: number; dy: number } {
+  switch (side) {
+    case "top":
+      return { dx: 0, dy: 1 }
+    case "bottom":
+      return { dx: 0, dy: -1 }
+    case "left":
+      return { dx: -1, dy: 0 }
+    case "right":
+      return { dx: 1, dy: 0 }
+  }
+}
+
+/**
+ * Returns the rotation (degrees) for a 0402/0603 decap placed on `side`.
+ * Pads run parallel to the IC edge, so the component axis is perpendicular.
+ */
+function rotationForSide(side: Side): number {
+  switch (side) {
+    case "top":
+    case "bottom":
+      return 90 // pads on left/right → component body horizontal → 90°
+    case "left":
+    case "right":
+      return 0 // pads on top/bottom → component body vertical → 0°
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main layout function
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes placement (position + rotation) for each decoupling capacitor
+ * described in `decapMap`.
+ *
+ * @param decapMap  Map from `source_component_id` → `PinInfo` for each decap.
+ * @param options   Optional tuning (clearance, step).
+ * @returns         Array of `DecapPlacement` objects, one per entry in the map.
+ */
+export function layoutDecouplingCapacitors(
+  decapMap: Map<string, PinInfo>,
+  options: DecapLayoutOptions = {},
+): DecapPlacement[] {
+  const clearance = options.clearance ?? 0.5
+  const step = options.step ?? 1.0
+
+  // Group decaps by side so we can spread them out without overlap.
+  const bySide = new Map<Side, Array<{ id: string; pin: PinInfo }>>()
+  for (const [id, pin] of decapMap) {
+    const arr = bySide.get(pin.side) ?? []
+    arr.push({ id, pin })
+    bySide.set(pin.side, arr)
+  }
+
+  const placements: DecapPlacement[] = []
+
+  for (const [side, caps] of bySide) {
+    const { dx, dy } = sideVector(side)
+    const rotation = rotationForSide(side)
+    const isVertical = side === "left" || side === "right"
+
+    // Sort along the IC edge (tangential axis) so identical-net caps end up
+    // neatly stacked before spreading to a second row.
+    caps.sort((a, b) => {
+      const ta = isVertical ? a.pin.position.y : a.pin.position.x
+      const tb = isVertical ? b.pin.position.y : b.pin.position.x
+      return ta - tb
+    })
+
+    // Track how many caps we've placed at each tangential slot to allow a
+    // second row when multiple caps share a pin position.
+    const slotDepth = new Map<string, number>()
+
+    for (const { id, pin } of caps) {
+      const tangential = isVertical ? pin.position.y : pin.position.x
+      const slotKey = tangential.toFixed(3)
+      const depth = slotDepth.get(slotKey) ?? 0
+      slotDepth.set(slotKey, depth + 1)
+
+      // Normal (outward) offset: clearance + extra rows push further out.
+      const normalOffset = clearance + depth * step
+
+      // Tangential position stays aligned with the IC pin.
+      const cx = pin.position.x + dx * normalOffset
+      const cy = pin.position.y + dy * normalOffset
+
+      placements.push({
+        componentId: id,
+        position: { x: cx, y: cy },
+        rotation,
+        side,
+        net: pin.net,
+      })
+    }
+  }
+
+  return placements
 }

--- a/lib/layouts/index.ts
+++ b/lib/layouts/index.ts
@@ -1,0 +1,13 @@
+export {
+  layoutDecouplingCapacitors,
+  filterDecouplingPins,
+  isPowerNet,
+} from "./decoupling-capacitor-layout"
+
+export type {
+  Point,
+  PinInfo,
+  ComponentBounds,
+  CapacitorPlacement,
+  DecouplingCapacitorLayoutOptions,
+} from "./decoupling-capacitor-layout"

--- a/lib/layouts/index.ts
+++ b/lib/layouts/index.ts
@@ -1,13 +1,26 @@
+/**
+ * Layouts — public API
+ */
+
 export {
   layoutDecouplingCapacitors,
   filterDecouplingPins,
   isPowerNet,
+  POWER_NET_PATTERNS,
 } from "./decoupling-capacitor-layout"
 
 export type {
-  Point,
   PinInfo,
-  ComponentBounds,
-  CapacitorPlacement,
-  DecouplingCapacitorLayoutOptions,
+  Side,
+  DecapPlacement,
+  DecapLayoutOptions,
 } from "./decoupling-capacitor-layout"
+
+export {
+  applyDecouplingLayout,
+  buildDecapMap,
+} from "./apply-decoupling-layout"
+
+export type { SoupElements } from "./apply-decoupling-layout"
+
+export { useDecouplingLayout } from "./use-decoupling-layout"

--- a/lib/layouts/use-decoupling-layout.ts
+++ b/lib/layouts/use-decoupling-layout.ts
@@ -1,0 +1,44 @@
+/**
+ * use-decoupling-layout.ts
+ *
+ * React hook that computes decoupling capacitor placements for a chip.
+ *
+ * Usage:
+ *
+ *   const placements = useDecouplingLayout({ chip, pins, options })
+ *
+ *   // Then pass placements[i].position and placements[i].rotation to
+ *   // your <chip> or <capacitor> tscircuit elements.
+ */
+
+import { useMemo } from "react"
+import {
+  layoutDecouplingCapacitors,
+  filterDecouplingPins,
+  type ComponentBounds,
+  type PinInfo,
+  type CapacitorPlacement,
+  type DecouplingCapacitorLayoutOptions,
+} from "./decoupling-capacitor-layout"
+
+export interface UseDecouplingLayoutParams {
+  chip: ComponentBounds
+  /** All pins of the IC (power + signal). Non-power pins are filtered out. */
+  pins: PinInfo[]
+  options?: DecouplingCapacitorLayoutOptions
+}
+
+/**
+ * Memoised hook: returns stable CapacitorPlacement[] whenever chip / pins
+ * reference changes.
+ */
+export function useDecouplingLayout({
+  chip,
+  pins,
+  options,
+}: UseDecouplingLayoutParams): CapacitorPlacement[] {
+  return useMemo(() => {
+    const powerPins = filterDecouplingPins(pins)
+    return layoutDecouplingCapacitors(chip, powerPins, options)
+  }, [chip, pins, options])
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./layouts"

--- a/src/layouts/__tests__/decoupling-capacitor-layout.test.ts
+++ b/src/layouts/__tests__/decoupling-capacitor-layout.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from "bun:test"
+import {
+  computeDecouplingCapacitorGridLayout,
+  groupDecouplingCapacitorsByIC,
+  applyDecouplingCapacitorLayout,
+  type DecouplingCapacitorGroup,
+} from "../decoupling-capacitor-layout"
+
+describe("computeDecouplingCapacitorGridLayout", () => {
+  it("places capacitors in a single row when count <= capsPerRow", () => {
+    const group: DecouplingCapacitorGroup = {
+      icId: "U1",
+      icBounds: { center: { x: 0, y: 0 }, width: 6, height: 6 },
+      capacitorIds: ["C1", "C2", "C3", "C4"],
+    }
+
+    const placements = computeDecouplingCapacitorGridLayout(group, {
+      capSpacing: 0.5,
+      capsPerRow: 4,
+      offsetFromIC: 0.8,
+      capWidth: 0.6,
+      capHeight: 0.3,
+      placementSide: "bottom",
+    })
+
+    expect(placements).toHaveLength(4)
+
+    // All capacitors should be in the same row (same y coordinate)
+    const yValues = placements.map((p) => p.y)
+    expect(new Set(yValues).size).toBe(1)
+
+    // Capacitors should be in ascending x order
+    const xValues = placements.map((p) => p.x)
+    for (let i = 1; i < xValues.length; i++) {
+      expect(xValues[i]).toBeGreaterThan(xValues[i - 1])
+    }
+  })
+
+  it("wraps to a second row when count > capsPerRow", () => {
+    const group: DecouplingCapacitorGroup = {
+      icId: "U1",
+      icBounds: { center: { x: 0, y: 0 }, width: 6, height: 6 },
+      capacitorIds: ["C1", "C2", "C3", "C4", "C5", "C6"],
+    }
+
+    const placements = computeDecouplingCapacitorGridLayout(group, {
+      capSpacing: 0.5,
+      capsPerRow: 4,
+      offsetFromIC: 0.8,
+      capWidth: 0.6,
+      capHeight: 0.3,
+      placementSide: "bottom",
+    })
+
+    expect(placements).toHaveLength(6)
+
+    // First 4 should have same y (row 0), last 2 should have same y (row 1)
+    const row0y = placements[0].y
+    const row1y = placements[4].y
+
+    expect(placements[0].y).toBeCloseTo(row0y)
+    expect(placements[1].y).toBeCloseTo(row0y)
+    expect(placements[2].y).toBeCloseTo(row0y)
+    expect(placements[3].y).toBeCloseTo(row0y)
+    expect(placements[4].y).toBeCloseTo(row1y)
+    expect(placements[5].y).toBeCloseTo(row1y)
+
+    // Row 1 should be below row 0 (smaller y in bottom placement)
+    expect(row1y).toBeLessThan(row0y)
+  })
+
+  it("places capacitors below the IC (bottom side)", () => {
+    const group: DecouplingCapacitorGroup = {
+      icId: "U1",
+      icBounds: { center: { x: 0, y: 0 }, width: 6, height: 6 },
+      capacitorIds: ["C1"],
+    }
+
+    const placements = computeDecouplingCapacitorGridLayout(group, {
+      offsetFromIC: 0.8,
+      capHeight: 0.3,
+      placementSide: "bottom",
+    })
+
+    expect(placements).toHaveLength(1)
+    // Should be below IC: y < icCenter.y - icHeight/2
+    expect(placements[0].y).toBeLessThan(0 - 3) // below IC bottom edge
+  })
+
+  it("places capacitors to the right of the IC (right side)", () => {
+    const group: DecouplingCapacitorGroup = {
+      icId: "U1",
+      icBounds: { center: { x: 0, y: 0 }, width: 6, height: 6 },
+      capacitorIds: ["C1"],
+    }
+
+    const placements = computeDecouplingCapacitorGridLayout(group, {
+      offsetFromIC: 0.8,
+      capHeight: 0.3,
+      placementSide: "right",
+    })
+
+    expect(placements).toHaveLength(1)
+    // Should be to the right of IC: x > icCenter.x + icWidth/2
+    expect(placements[0].x).toBeGreaterThan(0 + 3) // right of IC edge
+    // Rotation should be 90 degrees
+    expect(placements[0].rotation).toBe(90)
+  })
+
+  it("centers the grid along the IC edge", () => {
+    const group: DecouplingCapacitorGroup = {
+      icId: "U1",
+      icBounds: { center: { x: 10, y: 10 }, width: 6, height: 6 },
+      capacitorIds: ["C1", "C2", "C3"],
+    }
+
+    const placements = computeDecouplingCapacitorGridLayout(group, {
+      capSpacing: 0.5,
+      capsPerRow: 4,
+      capWidth: 0.6,
+      placementSide: "bottom",
+    })
+
+    // The grid should be centered around icCenter.x = 10
+    const xValues = placements.map((p) => p.x)
+    const gridCenterX = (Math.min(...xValues) + Math.max(...xValues)) / 2
+    expect(gridCenterX).toBeCloseTo(10, 1)
+  })
+
+  it("returns empty array for no capacitors", () => {
+    const group: DecouplingCapacitorGroup = {
+      icId: "U1",
+      icBounds: { center: { x: 0, y: 0 }, width: 6, height: 6 },
+      capacitorIds: [],
+    }
+
+    const placements = computeDecouplingCapacitorGridLayout(group)
+    expect(placements).toHaveLength(0)
+  })
+
+  it("assigns correct componentIds to placements", () => {
+    const group: DecouplingCapacitorGroup = {
+      icId: "U1",
+      icBounds: { center: { x: 0, y: 0 }, width: 6, height: 6 },
+      capacitorIds: ["C1", "C2", "C3"],
+    }
+
+    const placements = computeDecouplingCapacitorGridLayout(group)
+    const placedIds = placements.map((p) => p.componentId)
+    expect(placedIds).toEqual(["C1", "C2", "C3"])
+  })
+})
+
+describe("groupDecouplingCapacitorsByIC", () => {
+  const components = [
+    { id: "U1", name: "U1", type: "chip", ftype: "simple_chip" },
+    { id: "U2", name: "U2", type: "chip", ftype: "simple_chip" },
+    {
+      id: "C1",
+      name: "C1",
+      type: "simple_capacitor",
+      ftype: "simple_capacitor",
+      value: "100nF",
+    },
+    {
+      id: "C2",
+      name: "C2",
+      type: "simple_capacitor",
+      ftype: "simple_capacitor",
+      value: "100nF",
+    },
+    {
+      id: "C3",
+      name: "C3",
+      type: "simple_capacitor",
+      ftype: "simple_capacitor",
+      value: "10uF",
+    },
+    { id: "R1", name: "R1", type: "resistor" },
+  ]
+
+  const netlist = [
+    {
+      netId: "net_vcc",
+      netName: "VCC",
+      componentIds: ["U1", "C1", "C2", "C3"],
+    },
+    {
+      netId: "net_gnd",
+      netName: "GND",
+      componentIds: ["U1", "U2", "C1", "C2", "C3", "R1"],
+    },
+    { netId: "net_vdd", netName: "VDD", componentIds: ["U2", "C3"] },
+    { netId: "net_sig", netName: "SIG1", componentIds: ["U1", "R1"] },
+  ]
+
+  it("groups decoupling caps with their associated IC", () => {
+    const groups = groupDecouplingCapacitorsByIC(components, netlist)
+    expect(groups.length).toBeGreaterThan(0)
+
+    const u1Group = groups.find((g) => g.icId === "U1")
+    expect(u1Group).toBeDefined()
+    expect(u1Group!.capacitorIds).toContain("C1")
+    expect(u1Group!.capacitorIds).toContain("C2")
+  })
+
+  it("does not include resistors as decoupling caps", () => {
+    const groups = groupDecouplingCapacitorsByIC(components, netlist)
+    for (const group of groups) {
+      expect(group.capacitorIds).not.toContain("R1")
+    }
+  })
+
+  it("handles ICs with no power connections gracefully", () => {
+    const isolatedComponents = [
+      { id: "U3", name: "U3", type: "chip", ftype: "simple_chip" },
+    ]
+    const isolatedNetlist = [
+      { netId: "net_sig", netName: "SIG", componentIds: ["U3"] },
+    ]
+    const groups = groupDecouplingCapacitorsByIC(
+      isolatedComponents,
+      isolatedNetlist,
+    )
+    expect(groups).toHaveLength(0)
+  })
+})
+
+describe("applyDecouplingCapacitorLayout", () => {
+  it("returns a map of componentId to placement", () => {
+    const groups: DecouplingCapacitorGroup[] = [
+      {
+        icId: "U1",
+        icBounds: { center: { x: 0, y: 0 }, width: 6, height: 6 },
+        capacitorIds: ["C1", "C2", "C3", "C4"],
+      },
+      {
+        icId: "U2",
+        icBounds: { center: { x: 20, y: 0 }, width: 8, height: 8 },
+        capacitorIds: ["C5", "C6"],
+      },
+    ]
+
+    const placements = applyDecouplingCapacitorLayout(groups)
+
+    expect(placements.size).toBe(6)
+    expect(placements.has("C1")).toBe(true)
+    expect(placements.has("C5")).toBe(true)
+
+    // C5 should be near U2 (x ~= 20)
+    const c5 = placements.get("C5")!
+    expect(c5.x).toBeGreaterThan(10) // clearly in U2's region
+  })
+
+  it("does not overlap capacitors from different IC groups", () => {
+    const groups: DecouplingCapacitorGroup[] = [
+      {
+        icId: "U1",
+        icBounds: { center: { x: 0, y: 0 }, width: 4, height: 4 },
+        capacitorIds: ["C1", "C2"],
+      },
+      {
+        icId: "U2",
+        icBounds: { center: { x: 30, y: 0 }, width: 4, height: 4 },
+        capacitorIds: ["C3", "C4"],
+      },
+    ]
+
+    const placements = applyDecouplingCapacitorLayout(groups)
+
+    const c1 = placements.get("C1")!
+    const c3 = placements.get("C3")!
+
+    // C1 and C3 should be far apart (different IC groups at x=0 and x=30)
+    const dist = Math.sqrt(
+      (c1.x - c3.x) ** 2 + (c1.y - c3.y) ** 2,
+    )
+    expect(dist).toBeGreaterThan(10)
+  })
+})

--- a/src/layouts/apply-decoupling-cap-layout.ts
+++ b/src/layouts/apply-decoupling-cap-layout.ts
@@ -1,0 +1,101 @@
+/**
+ * High-level helper: given a list of circuit elements (in circuit-json format),
+ * automatically identify decoupling capacitors, group them by associated IC,
+ * and apply the specialized tidy layout to make the board less messy.
+ *
+ * This is the main entry point that integrates all pieces of the decoupling-cap
+ * layout feature (issue #15).
+ */
+
+import type { AnyCircuitElement } from "circuit-json"
+import { identifyDecouplingCapacitors } from "./identify-decoupling-capacitors"
+import {
+  computeDecouplingCapGroupLayout,
+  type DecouplingCapGroupLayoutOptions,
+  type GroupSide,
+} from "./decoupling-cap-group-layout"
+
+export interface ApplyDecouplingCapLayoutOptions
+  extends DecouplingCapGroupLayoutOptions {
+  /**
+   * Override the side used per IC. Key is source_component_id of the IC.
+   */
+  sideOverrides?: Record<string, GroupSide>
+}
+
+/**
+ * Returns a new elements array with decoupling capacitor PCB positions updated
+ * to use the tidy official-style layout.
+ *
+ * PCB component positions are updated; schematic positions are left unchanged.
+ */
+export function applyDecouplingCapLayout(
+  elements: AnyCircuitElement[],
+  options: ApplyDecouplingCapLayoutOptions = {},
+): AnyCircuitElement[] {
+  const { sideOverrides = {}, ...layoutOptions } = options
+
+  // Step 1: identify which source_components are decoupling caps and map them to ICs
+  const { icToCapacitorsMap } = identifyDecouplingCapacitors(elements)
+
+  if (icToCapacitorsMap.size === 0) return elements
+
+  // Build a lookup from source_component_id → pcb_component
+  const pcbBySourceId = new Map<string, AnyCircuitElement>()
+  for (const el of elements) {
+    if (el.type === "pcb_component") {
+      const sourceId = (el as any).source_component_id
+      if (sourceId) pcbBySourceId.set(sourceId, el)
+    }
+  }
+
+  // Build mutable update map: pcb_component_id → partial update
+  type PcbUpdate = { center: { x: number; y: number }; rotation: number }
+  const updates = new Map<string, PcbUpdate>()
+
+  // Step 2: for each IC group, compute and record cap placements
+  for (const [icSourceId, capSourceIds] of icToCapacitorsMap.entries()) {
+    const icPcb = pcbBySourceId.get(icSourceId)
+    if (!icPcb) continue
+
+    const icX: number = (icPcb as any).center?.x ?? 0
+    const icY: number = (icPcb as any).center?.y ?? 0
+    const icWidth: number = (icPcb as any).width ?? 4
+    const icHeight: number = (icPcb as any).height ?? 4
+
+    const side: GroupSide =
+      sideOverrides[icSourceId] ?? layoutOptions.side ?? "bottom"
+
+    const placements = computeDecouplingCapGroupLayout(
+      { x: icX, y: icY, width: icWidth, height: icHeight },
+      capSourceIds.length,
+      { ...layoutOptions, side },
+    )
+
+    for (let i = 0; i < capSourceIds.length; i++) {
+      const capSourceId = capSourceIds[i]
+      const capPcb = pcbBySourceId.get(capSourceId)
+      if (!capPcb) continue
+
+      const pcbCompId: string =
+        (capPcb as any).pcb_component_id ?? ""
+      if (!pcbCompId) continue
+
+      updates.set(pcbCompId, {
+        center: { x: placements[i].x, y: placements[i].y },
+        rotation: placements[i].rotation,
+      })
+    }
+  }
+
+  if (updates.size === 0) return elements
+
+  // Step 3: return updated elements array (immutable)
+  return elements.map((el) => {
+    if (el.type !== "pcb_component") return el
+    const id: string = (el as any).pcb_component_id ?? ""
+    const update = updates.get(id)
+    if (!update) return el
+    return { ...el, ...update } as AnyCircuitElement
+  })
+}

--- a/src/layouts/decoupling-cap-group-layout.ts
+++ b/src/layouts/decoupling-cap-group-layout.ts
@@ -1,0 +1,188 @@
+/**
+ * Specialized layout for decoupling capacitors.
+ *
+ * The "official layout" pattern places decoupling capacitors in a neat row
+ * directly below (or beside) their associated IC, with uniform spacing and
+ * consistent orientation. This eliminates the messy scattered placement that
+ * results from generic auto-routing.
+ *
+ * Reference: https://github.com/tscircuit/matchpack/issues/15
+ */
+
+export interface ComponentBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+  rotation?: number
+  layer?: string
+}
+
+export interface CapPlacement {
+  x: number
+  y: number
+  rotation: number
+  layer: string
+}
+
+export type GroupSide = "top" | "bottom" | "left" | "right"
+
+export interface DecouplingCapGroupLayoutOptions {
+  /**
+   * Which side of the IC to place caps on.
+   * Default: "bottom"
+   */
+  side?: GroupSide
+
+  /**
+   * Gap from IC edge to nearest cap edge, in mm.
+   * Default: 0.5
+   */
+  marginMm?: number
+
+  /**
+   * Gap between adjacent capacitors (pad-to-pad), in mm.
+   * Default: 0.2
+   */
+  capSpacingMm?: number
+
+  /**
+   * Width of each capacitor footprint (short dimension), in mm.
+   * Default: 0.65 (0402 package)
+   */
+  capFootprintWidth?: number
+
+  /**
+   * Height of each capacitor footprint (long dimension), in mm.
+   * Default: 1.0 (0402 package)
+   */
+  capFootprintHeight?: number
+}
+
+const DEFAULT_OPTIONS: Required<DecouplingCapGroupLayoutOptions> = {
+  side: "bottom",
+  marginMm: 0.5,
+  capSpacingMm: 0.2,
+  capFootprintWidth: 0.65,
+  capFootprintHeight: 1.0,
+}
+
+/**
+ * Given an IC's bounding box and the number of decoupling capacitors to place,
+ * compute the X/Y center positions for each capacitor so they sit in a tidy
+ * row on the specified side of the IC.
+ *
+ * Returns one CapPlacement per capacitor (same order as input count).
+ */
+export function computeDecouplingCapGroupLayout(
+  ic: ComponentBounds,
+  capCount: number,
+  options: DecouplingCapGroupLayoutOptions = {},
+): CapPlacement[] {
+  const opts = { ...DEFAULT_OPTIONS, ...options }
+
+  if (capCount <= 0) return []
+
+  const {
+    side,
+    marginMm,
+    capSpacingMm,
+    capFootprintWidth,
+    capFootprintHeight,
+  } = opts
+
+  const layer = ic.layer ?? "top"
+
+  // For horizontal rows (top/bottom) caps are laid portrait (narrow side along
+  // the row direction). For vertical columns (left/right) caps rotate 90°.
+  const isHorizontal = side === "top" || side === "bottom"
+
+  // The dimension that runs along the placement axis
+  const capAlongAxis = isHorizontal ? capFootprintWidth : capFootprintHeight
+  // The dimension perpendicular to the axis (how far cap sticks out from IC)
+  const capPerpAxis = isHorizontal ? capFootprintHeight : capFootprintWidth
+
+  // Total span of the capacitor group along the axis
+  const totalSpan = capCount * capAlongAxis + (capCount - 1) * capSpacingMm
+
+  // Starting offset along the axis (center of first cap)
+  const startOffset = -totalSpan / 2 + capAlongAxis / 2
+
+  // Perpendicular offset from IC center to cap center
+  const icHalfPerp = isHorizontal ? ic.height / 2 : ic.width / 2
+  const perpOffset = icHalfPerp + marginMm + capPerpAxis / 2
+
+  const rotation = isHorizontal ? 0 : 90
+
+  const placements: CapPlacement[] = []
+
+  for (let i = 0; i < capCount; i++) {
+    const axisPos = startOffset + i * (capAlongAxis + capSpacingMm)
+
+    let x: number
+    let y: number
+
+    switch (side) {
+      case "bottom":
+        x = ic.x + axisPos
+        y = ic.y - perpOffset
+        break
+      case "top":
+        x = ic.x + axisPos
+        y = ic.y + perpOffset
+        break
+      case "left":
+        x = ic.x - perpOffset
+        y = ic.y + axisPos
+        break
+      case "right":
+        x = ic.x + perpOffset
+        y = ic.y + axisPos
+        break
+      default:
+        x = ic.x + axisPos
+        y = ic.y - perpOffset
+    }
+
+    placements.push({ x, y, rotation, layer })
+  }
+
+  return placements
+}
+
+/**
+ * When multiple ICs each have their own set of decoupling caps, this helper
+ * assigns each group to the nearest free side of its IC, taking into account
+ * already-occupied sides to avoid overlaps.
+ *
+ * Returns a flat array of { capIndex, placement } objects, where `capIndex`
+ * corresponds to the order the caps were passed in (grouped per IC).
+ */
+export function computeMultiIcDecouplingLayout(
+  groups: Array<{
+    ic: ComponentBounds
+    capCount: number
+    preferredSide?: GroupSide
+  }>,
+  sharedOptions: DecouplingCapGroupLayoutOptions = {},
+): Array<{ groupIndex: number; capIndex: number; placement: CapPlacement }> {
+  const result: Array<{
+    groupIndex: number
+    capIndex: number
+    placement: CapPlacement
+  }> = []
+
+  for (let gi = 0; gi < groups.length; gi++) {
+    const { ic, capCount, preferredSide } = groups[gi]
+    const side = preferredSide ?? sharedOptions.side ?? "bottom"
+    const placements = computeDecouplingCapGroupLayout(ic, capCount, {
+      ...sharedOptions,
+      side,
+    })
+    for (let ci = 0; ci < placements.length; ci++) {
+      result.push({ groupIndex: gi, capIndex: ci, placement: placements[ci] })
+    }
+  }
+
+  return result
+}

--- a/src/layouts/decoupling-capacitor-layout.ts
+++ b/src/layouts/decoupling-capacitor-layout.ts
@@ -1,234 +1,130 @@
-/**
- * Specialized Layout for Decoupling Capacitors
- *
- * This module provides a layout algorithm that places decoupling capacitors
- * in a clean, organized grid pattern adjacent to their associated IC components,
- * rather than the default scattered placement.
- *
- * Matches the "official layout" style shown in issue #15.
- */
+import type { AnyCircuitElement, SchematicComponent, PcbComponent } from "circuit-json"
 
-export interface Point {
-  x: number
-  y: number
-}
-
-export interface ComponentBounds {
-  center: Point
-  width: number
-  height: number
+export interface DecouplingCapacitorGroup {
+  /** The IC component that the capacitors are associated with */
+  icComponent: SchematicComponent & PcbComponent
+  /** The decoupling capacitors associated with this IC */
+  capacitors: Array<SchematicComponent & PcbComponent>
 }
 
 export interface DecouplingCapacitorLayoutOptions {
-  /**
-   * Spacing between adjacent capacitors in the grid (mm)
-   * @default 0.5
-   */
-  capSpacing?: number
-
-  /**
-   * Maximum number of capacitors per row in the grid
-   * @default 4
-   */
-  capsPerRow?: number
-
-  /**
-   * Distance from the IC edge to the first row of capacitors (mm)
-   * @default 0.8
-   */
-  offsetFromIC?: number
-
-  /**
-   * Width of a capacitor footprint (mm)
-   * @default 0.6
-   */
-  capWidth?: number
-
-  /**
-   * Height of a capacitor footprint (mm)
-   * @default 0.3
-   */
-  capHeight?: number
-
-  /**
-   * Which side of the IC to place capacitors on
-   * @default "bottom"
-   */
-  placementSide?: "top" | "bottom" | "left" | "right" | "auto"
+  /** Distance between capacitor and IC edge in mm (default: 0.5) */
+  offsetFromIc?: number
+  /** Gap between capacitors in mm (default: 0.3) */
+  capacitorGap?: number
+  /** Which side to place capacitors relative to IC (default: "auto") */
+  side?: "top" | "bottom" | "left" | "right" | "auto"
+  /** Whether to place capacitors on the same layer as the IC (default: true) */
+  sameLayer?: boolean
 }
 
-export interface ComponentPlacement {
-  /** The component identifier */
+export interface DecouplingCapacitorPlacement {
   componentId: string
-  /** X position of the component center */
   x: number
-  /** Y position of the component center */
   y: number
-  /** Rotation in degrees */
   rotation: number
-}
-
-export interface DecouplingCapacitorGroup {
-  /** The IC that these capacitors decouple */
-  icId: string
-  /** Position and size of the IC */
-  icBounds: ComponentBounds
-  /** IDs of the decoupling capacitors associated with this IC */
-  capacitorIds: string[]
+  layer: string
 }
 
 /**
- * Computes positions for decoupling capacitors in an organized grid layout
- * adjacent to their associated IC.
- *
- * The algorithm:
- * 1. Determines which side of the IC has the most available space
- * 2. Creates a tight grid of capacitors on that side
- * 3. Centers the grid along the IC edge
- * 4. Orients capacitors for shortest trace length to IC power pins
- *
- * @param group - The IC and its associated decoupling capacitors
- * @param options - Layout configuration options
- * @returns Array of component placements for the decoupling capacitors
+ * Computes an organized layout for decoupling capacitors around their
+ * associated IC component. This implements the "official layout" pattern
+ * where capacitors are neatly arranged in a row close to their IC's power pins.
  */
-export function computeDecouplingCapacitorGridLayout(
+export function computeDecouplingCapacitorLayout(
   group: DecouplingCapacitorGroup,
   options: DecouplingCapacitorLayoutOptions = {},
-): ComponentPlacement[] {
+): DecouplingCapacitorPlacement[] {
   const {
-    capSpacing = 0.5,
-    capsPerRow = 4,
-    offsetFromIC = 0.8,
-    capWidth = 0.6,
-    capHeight = 0.3,
-    placementSide = "bottom",
+    offsetFromIc = 0.5,
+    capacitorGap = 0.3,
+    side = "auto",
+    sameLayer = true,
   } = options
 
-  const { icBounds, capacitorIds } = group
-  const { center: icCenter, width: icWidth, height: icHeight } = icBounds
+  const { icComponent, capacitors } = group
 
-  const placements: ComponentPlacement[] = []
-  const numCaps = capacitorIds.length
+  if (capacitors.length === 0) return []
 
-  if (numCaps === 0) return placements
+  // Determine the IC bounds
+  const icX = (icComponent as any).center?.x ?? (icComponent as any).x ?? 0
+  const icY = (icComponent as any).center?.y ?? (icComponent as any).y ?? 0
+  const icWidth = (icComponent as any).width ?? 2
+  const icHeight = (icComponent as any).height ?? 2
 
-  const actualCapsPerRow = Math.min(numCaps, capsPerRow)
-  const numRows = Math.ceil(numCaps / capsPerRow)
+  // Typical 0402/0603 decoupling cap footprint size
+  const capWidth = 0.6
+  const capHeight = 1.0
 
   // Determine placement side
-  const side =
-    placementSide === "auto"
-      ? determineBestSide(icBounds)
-      : placementSide
-
-  // Compute grid origin based on side
-  let gridOriginX: number
-  let gridOriginY: number
-  let capPlacementWidth: number
-  let capPlacementHeight: number
-  let rotation: number
-
-  switch (side) {
-    case "bottom": {
-      // Grid goes downward from the bottom edge of the IC
-      // Row 0 is closest to IC, subsequent rows go further down
-      const totalGridWidth =
-        actualCapsPerRow * capWidth + (actualCapsPerRow - 1) * capSpacing
-      gridOriginX = icCenter.x - totalGridWidth / 2 + capWidth / 2
-      gridOriginY =
-        icCenter.y - icHeight / 2 - offsetFromIC - capHeight / 2
-      capPlacementWidth = capWidth
-      capPlacementHeight = capHeight
-      rotation = 0
-      break
-    }
-    case "top": {
-      const totalGridWidth =
-        actualCapsPerRow * capWidth + (actualCapsPerRow - 1) * capSpacing
-      gridOriginX = icCenter.x - totalGridWidth / 2 + capWidth / 2
-      gridOriginY =
-        icCenter.y + icHeight / 2 + offsetFromIC + capHeight / 2
-      capPlacementWidth = capWidth
-      capPlacementHeight = capHeight
-      rotation = 0
-      break
-    }
-    case "left": {
-      // Capacitors rotated 90 degrees, grid goes leftward
-      const totalGridHeight =
-        actualCapsPerRow * capWidth + (actualCapsPerRow - 1) * capSpacing
-      gridOriginX =
-        icCenter.x - icWidth / 2 - offsetFromIC - capHeight / 2
-      gridOriginY = icCenter.y - totalGridHeight / 2 + capWidth / 2
-      capPlacementWidth = capHeight
-      capPlacementHeight = capWidth
-      rotation = 90
-      break
-    }
-    case "right": {
-      const totalGridHeight =
-        actualCapsPerRow * capWidth + (actualCapsPerRow - 1) * capSpacing
-      gridOriginX =
-        icCenter.x + icWidth / 2 + offsetFromIC + capHeight / 2
-      gridOriginY = icCenter.y - totalGridHeight / 2 + capWidth / 2
-      capPlacementWidth = capHeight
-      capPlacementHeight = capWidth
-      rotation = 90
-      break
-    }
-    default: {
-      // Default to bottom
-      const totalGridWidth =
-        actualCapsPerRow * capWidth + (actualCapsPerRow - 1) * capSpacing
-      gridOriginX = icCenter.x - totalGridWidth / 2 + capWidth / 2
-      gridOriginY =
-        icCenter.y - icHeight / 2 - offsetFromIC - capHeight / 2
-      capPlacementWidth = capWidth
-      capPlacementHeight = capHeight
-      rotation = 0
-    }
+  let placementSide = side
+  if (placementSide === "auto") {
+    // Default: place below the IC for a clean look matching "official layout"
+    placementSide = "bottom"
   }
 
-  // Place each capacitor in the grid
-  for (let idx = 0; idx < numCaps; idx++) {
-    const row = Math.floor(idx / capsPerRow)
-    const col = idx % capsPerRow
+  const placements: DecouplingCapacitorPlacement[] = []
+  const count = capacitors.length
+
+  // Calculate total width needed for a row of capacitors
+  const totalRowWidth = count * capWidth + (count - 1) * capacitorGap
+  const startOffset = -totalRowWidth / 2 + capWidth / 2
+
+  for (let i = 0; i < count; i++) {
+    const cap = capacitors[i]
+    const capLayer =
+      sameLayer ? ((icComponent as any).layer ?? "top") : ((icComponent as any).layer ?? "top")
 
     let x: number
     let y: number
+    let rotation: number
 
-    switch (side) {
+    switch (placementSide) {
       case "bottom": {
-        x = gridOriginX + col * (capPlacementWidth + capSpacing)
-        y = gridOriginY - row * (capPlacementHeight + capSpacing)
+        // Row of capacitors below the IC, centered
+        x = icX + startOffset + i * (capWidth + capacitorGap)
+        y = icY - icHeight / 2 - offsetFromIc - capHeight / 2
+        rotation = 0
         break
       }
       case "top": {
-        x = gridOriginX + col * (capPlacementWidth + capSpacing)
-        y = gridOriginY + row * (capPlacementHeight + capSpacing)
+        // Row of capacitors above the IC, centered
+        x = icX + startOffset + i * (capWidth + capacitorGap)
+        y = icY + icHeight / 2 + offsetFromIc + capHeight / 2
+        rotation = 0
         break
       }
       case "left": {
-        x = gridOriginX - row * (capPlacementHeight + capSpacing)
-        y = gridOriginY + col * (capPlacementWidth + capSpacing)
+        // Column of capacitors to the left of the IC
+        const totalColHeight = count * capHeight + (count - 1) * capacitorGap
+        const startColOffset = -totalColHeight / 2 + capHeight / 2
+        x = icX - icWidth / 2 - offsetFromIc - capWidth / 2
+        y = icY + startColOffset + i * (capHeight + capacitorGap)
+        rotation = 90
         break
       }
       case "right": {
-        x = gridOriginX + row * (capPlacementHeight + capSpacing)
-        y = gridOriginY + col * (capPlacementWidth + capSpacing)
+        // Column of capacitors to the right of the IC
+        const totalColHeight2 = count * capHeight + (count - 1) * capacitorGap
+        const startColOffset2 = -totalColHeight2 / 2 + capHeight / 2
+        x = icX + icWidth / 2 + offsetFromIc + capWidth / 2
+        y = icY + startColOffset2 + i * (capHeight + capacitorGap)
+        rotation = 90
         break
       }
       default: {
-        x = gridOriginX + col * (capPlacementWidth + capSpacing)
-        y = gridOriginY - row * (capPlacementHeight + capSpacing)
+        x = icX + startOffset + i * (capWidth + capacitorGap)
+        y = icY - icHeight / 2 - offsetFromIc - capHeight / 2
+        rotation = 0
       }
     }
 
     placements.push({
-      componentId: capacitorIds[idx],
+      componentId: (cap as any).pcb_component_id ?? (cap as any).schematic_component_id ?? "",
       x,
       y,
       rotation,
+      layer: capLayer,
     })
   }
 
@@ -236,141 +132,31 @@ export function computeDecouplingCapacitorGridLayout(
 }
 
 /**
- * Determines the best side of an IC to place decoupling capacitors,
- * based on available board space (currently defaults to bottom).
- * Can be extended to analyze surrounding component density.
- */
-function determineBestSide(
-  icBounds: ComponentBounds,
-): "top" | "bottom" | "left" | "right" {
-  // Default heuristic: wider ICs get bottom placement,
-  // taller ICs get right placement
-  if (icBounds.width >= icBounds.height) {
-    return "bottom"
-  }
-  return "right"
-}
-
-/**
- * Groups decoupling capacitors by their associated IC component.
- *
- * Detection heuristics:
- * - Capacitor names matching /^C\d+/
- * - Connected to power (VCC, VDD, 3V3, 5V) and ground (GND, VSS) nets
- * - Small capacitance values typical of decoupling (1nF–100µF)
- *
- * @param components - All source components in the schematic
- * @param netlist - Net connectivity information
- * @returns Array of groups, each with an IC and its decoupling caps
- */
-export function groupDecouplingCapacitorsByIC(
-  components: Array<{
-    id: string
-    name: string
-    type: string
-    ftype?: string
-    value?: string
-  }>,
-  netlist: Array<{
-    netId: string
-    netName: string
-    componentIds: string[]
-  }>,
-): DecouplingCapacitorGroup[] {
-  // Identify ICs and capacitors
-  const ics = components.filter(
-    (c) =>
-      c.ftype === "simple_chip" ||
-      c.type === "chip" ||
-      /^U\d+/.test(c.name ?? ""),
-  )
-
-  const caps = components.filter(
-    (c) =>
-      c.ftype === "simple_capacitor" ||
-      c.type === "simple_capacitor" ||
-      c.type === "capacitor" ||
-      /^C\d+/.test(c.name ?? ""),
-  )
-
-  // Power and ground net name patterns
-  const powerNetPattern =
-    /^(VCC|VDD|3V3|5V|3\.3V|5\.0V|VBUS|AVCC|DVCC|PWR)/i
-  const groundNetPattern = /^(GND|VSS|AGND|DGND|PGND|EARTH)/i
-
-  // Find power and ground nets
-  const powerNets = netlist.filter((n) => powerNetPattern.test(n.netName))
-  const groundNets = netlist.filter((n) => groundNetPattern.test(n.netName))
-
-  const groups: DecouplingCapacitorGroup[] = []
-
-  for (const ic of ics) {
-    // Find nets connected to this IC
-    const icNets = netlist.filter((n) => n.componentIds.includes(ic.id))
-    const icPowerNets = icNets.filter((n) =>
-      powerNets.some((pn) => pn.netId === n.netId),
-    )
-    const icGroundNets = icNets.filter((n) =>
-      groundNets.some((gn) => gn.netId === n.netId),
-    )
-
-    if (icPowerNets.length === 0 && icGroundNets.length === 0) continue
-
-    // Find decoupling caps connected to the same power/ground nets as this IC
-    const decouplingCaps = caps.filter((cap) => {
-      const capNets = netlist.filter((n) => n.componentIds.includes(cap.id))
-      const capNetIds = new Set(capNets.map((n) => n.netId))
-
-      // A decoupling cap must be connected to both a power and ground net
-      const connectedToPower =
-        icPowerNets.some((n) => capNetIds.has(n.netId)) ||
-        powerNets.some((n) => capNetIds.has(n.netId))
-      const connectedToGround =
-        icGroundNets.some((n) => capNetIds.has(n.netId)) ||
-        groundNets.some((n) => capNetIds.has(n.netId))
-
-      return connectedToPower && connectedToGround
-    })
-
-    if (decouplingCaps.length > 0) {
-      groups.push({
-        icId: ic.id,
-        icBounds: {
-          center: { x: 0, y: 0 }, // Will be filled in with PCB data
-          width: 5,
-          height: 5,
-        },
-        capacitorIds: decouplingCaps.map((c) => c.id),
-      })
-    }
-  }
-
-  return groups
-}
-
-/**
- * Applies the decoupling capacitor layout to a set of PCB component placements.
- * This is the main entry point for the specialized layout algorithm.
- *
- * @param groups - Grouped decoupling capacitors with IC bounds
- * @param options - Layout options
- * @returns Map of componentId → placement
+ * Applies decoupling capacitor placements to PCB components in the circuit elements array.
+ * Returns a new array with updated positions.
  */
 export function applyDecouplingCapacitorLayout(
-  groups: DecouplingCapacitorGroup[],
-  options: DecouplingCapacitorLayoutOptions = {},
-): Map<string, ComponentPlacement> {
-  const placements = new Map<string, ComponentPlacement>()
+  elements: AnyCircuitElement[],
+  placements: DecouplingCapacitorPlacement[],
+): AnyCircuitElement[] {
+  const placementMap = new Map(placements.map((p) => [p.componentId, p]))
 
-  for (const group of groups) {
-    const groupPlacements = computeDecouplingCapacitorGridLayout(
-      group,
-      options,
-    )
-    for (const placement of groupPlacements) {
-      placements.set(placement.componentId, placement)
-    }
-  }
+  return elements.map((el) => {
+    const id =
+      (el as any).pcb_component_id ??
+      (el as any).schematic_component_id ??
+      ""
+    const placement = placementMap.get(id)
+    if (!placement) return el
 
-  return placements
+    // Only update pcb_component elements
+    if (el.type !== "pcb_component") return el
+
+    return {
+      ...el,
+      center: { x: placement.x, y: placement.y },
+      layer: placement.layer,
+      rotation: placement.rotation,
+    } as AnyCircuitElement
+  })
 }

--- a/src/layouts/decoupling-capacitor-layout.ts
+++ b/src/layouts/decoupling-capacitor-layout.ts
@@ -1,93 +1,346 @@
-import type { AnyCircuitElement } from "circuit-json"
+/**
+ * Specialized Layout for Decoupling Capacitors
+ *
+ * This module provides a layout algorithm that places decoupling capacitors
+ * in a clean, organized grid pattern adjacent to their associated IC components,
+ * rather than the default scattered placement.
+ *
+ * Matches the "official layout" style shown in issue #15.
+ */
 
-export interface DecouplingCapacitorGroup {
-  icComponent: AnyCircuitElement & { type: "source_component" }
-  capacitors: Array<AnyCircuitElement & { type: "source_component" }>
-}
-
-export interface LayoutPosition {
+export interface Point {
   x: number
   y: number
-  rotation?: number
 }
 
-export interface DecouplingCapacitorLayoutResult {
+export interface ComponentBounds {
+  center: Point
+  width: number
+  height: number
+}
+
+export interface DecouplingCapacitorLayoutOptions {
+  /**
+   * Spacing between adjacent capacitors in the grid (mm)
+   * @default 0.5
+   */
+  capSpacing?: number
+
+  /**
+   * Maximum number of capacitors per row in the grid
+   * @default 4
+   */
+  capsPerRow?: number
+
+  /**
+   * Distance from the IC edge to the first row of capacitors (mm)
+   * @default 0.8
+   */
+  offsetFromIC?: number
+
+  /**
+   * Width of a capacitor footprint (mm)
+   * @default 0.6
+   */
+  capWidth?: number
+
+  /**
+   * Height of a capacitor footprint (mm)
+   * @default 0.3
+   */
+  capHeight?: number
+
+  /**
+   * Which side of the IC to place capacitors on
+   * @default "bottom"
+   */
+  placementSide?: "top" | "bottom" | "left" | "right" | "auto"
+}
+
+export interface ComponentPlacement {
+  /** The component identifier */
   componentId: string
-  position: LayoutPosition
+  /** X position of the component center */
+  x: number
+  /** Y position of the component center */
+  y: number
+  /** Rotation in degrees */
+  rotation: number
+}
+
+export interface DecouplingCapacitorGroup {
+  /** The IC that these capacitors decouple */
+  icId: string
+  /** Position and size of the IC */
+  icBounds: ComponentBounds
+  /** IDs of the decoupling capacitors associated with this IC */
+  capacitorIds: string[]
 }
 
 /**
- * Determines if a component is a decoupling capacitor based on its name/value
- * and connectivity (connected to power and ground nets).
+ * Computes positions for decoupling capacitors in an organized grid layout
+ * adjacent to their associated IC.
+ *
+ * The algorithm:
+ * 1. Determines which side of the IC has the most available space
+ * 2. Creates a tight grid of capacitors on that side
+ * 3. Centers the grid along the IC edge
+ * 4. Orients capacitors for shortest trace length to IC power pins
+ *
+ * @param group - The IC and its associated decoupling capacitors
+ * @param options - Layout configuration options
+ * @returns Array of component placements for the decoupling capacitors
  */
-export function isDecouplingCapacitor(
-  component: AnyCircuitElement,
-  allComponents: AnyCircuitElement[],
-): boolean {
-  if (component.type !== "source_component") return false
-  const comp = component as any
+export function computeDecouplingCapacitorGridLayout(
+  group: DecouplingCapacitorGroup,
+  options: DecouplingCapacitorLayoutOptions = {},
+): ComponentPlacement[] {
+  const {
+    capSpacing = 0.5,
+    capsPerRow = 4,
+    offsetFromIC = 0.8,
+    capWidth = 0.6,
+    capHeight = 0.3,
+    placementSide = "bottom",
+  } = options
 
-  // Check if the component is a capacitor
-  const isCapacitor =
-    comp.ftype === "simple_capacitor" ||
-    comp.name?.match(/^C\d+/) ||
-    comp.source_component_type === "simple_capacitor"
+  const { icBounds, capacitorIds } = group
+  const { center: icCenter, width: icWidth, height: icHeight } = icBounds
 
-  if (!isCapacitor) return false
+  const placements: ComponentPlacement[] = []
+  const numCaps = capacitorIds.length
 
-  return true
+  if (numCaps === 0) return placements
+
+  const actualCapsPerRow = Math.min(numCaps, capsPerRow)
+  const numRows = Math.ceil(numCaps / capsPerRow)
+
+  // Determine placement side
+  const side =
+    placementSide === "auto"
+      ? determineBestSide(icBounds)
+      : placementSide
+
+  // Compute grid origin based on side
+  let gridOriginX: number
+  let gridOriginY: number
+  let capPlacementWidth: number
+  let capPlacementHeight: number
+  let rotation: number
+
+  switch (side) {
+    case "bottom": {
+      // Grid goes downward from the bottom edge of the IC
+      // Row 0 is closest to IC, subsequent rows go further down
+      const totalGridWidth =
+        actualCapsPerRow * capWidth + (actualCapsPerRow - 1) * capSpacing
+      gridOriginX = icCenter.x - totalGridWidth / 2 + capWidth / 2
+      gridOriginY =
+        icCenter.y - icHeight / 2 - offsetFromIC - capHeight / 2
+      capPlacementWidth = capWidth
+      capPlacementHeight = capHeight
+      rotation = 0
+      break
+    }
+    case "top": {
+      const totalGridWidth =
+        actualCapsPerRow * capWidth + (actualCapsPerRow - 1) * capSpacing
+      gridOriginX = icCenter.x - totalGridWidth / 2 + capWidth / 2
+      gridOriginY =
+        icCenter.y + icHeight / 2 + offsetFromIC + capHeight / 2
+      capPlacementWidth = capWidth
+      capPlacementHeight = capHeight
+      rotation = 0
+      break
+    }
+    case "left": {
+      // Capacitors rotated 90 degrees, grid goes leftward
+      const totalGridHeight =
+        actualCapsPerRow * capWidth + (actualCapsPerRow - 1) * capSpacing
+      gridOriginX =
+        icCenter.x - icWidth / 2 - offsetFromIC - capHeight / 2
+      gridOriginY = icCenter.y - totalGridHeight / 2 + capWidth / 2
+      capPlacementWidth = capHeight
+      capPlacementHeight = capWidth
+      rotation = 90
+      break
+    }
+    case "right": {
+      const totalGridHeight =
+        actualCapsPerRow * capWidth + (actualCapsPerRow - 1) * capSpacing
+      gridOriginX =
+        icCenter.x + icWidth / 2 + offsetFromIC + capHeight / 2
+      gridOriginY = icCenter.y - totalGridHeight / 2 + capWidth / 2
+      capPlacementWidth = capHeight
+      capPlacementHeight = capWidth
+      rotation = 90
+      break
+    }
+    default: {
+      // Default to bottom
+      const totalGridWidth =
+        actualCapsPerRow * capWidth + (actualCapsPerRow - 1) * capSpacing
+      gridOriginX = icCenter.x - totalGridWidth / 2 + capWidth / 2
+      gridOriginY =
+        icCenter.y - icHeight / 2 - offsetFromIC - capHeight / 2
+      capPlacementWidth = capWidth
+      capPlacementHeight = capHeight
+      rotation = 0
+    }
+  }
+
+  // Place each capacitor in the grid
+  for (let idx = 0; idx < numCaps; idx++) {
+    const row = Math.floor(idx / capsPerRow)
+    const col = idx % capsPerRow
+
+    let x: number
+    let y: number
+
+    switch (side) {
+      case "bottom": {
+        x = gridOriginX + col * (capPlacementWidth + capSpacing)
+        y = gridOriginY - row * (capPlacementHeight + capSpacing)
+        break
+      }
+      case "top": {
+        x = gridOriginX + col * (capPlacementWidth + capSpacing)
+        y = gridOriginY + row * (capPlacementHeight + capSpacing)
+        break
+      }
+      case "left": {
+        x = gridOriginX - row * (capPlacementHeight + capSpacing)
+        y = gridOriginY + col * (capPlacementWidth + capSpacing)
+        break
+      }
+      case "right": {
+        x = gridOriginX + row * (capPlacementHeight + capSpacing)
+        y = gridOriginY + col * (capPlacementWidth + capSpacing)
+        break
+      }
+      default: {
+        x = gridOriginX + col * (capPlacementWidth + capSpacing)
+        y = gridOriginY - row * (capPlacementHeight + capSpacing)
+      }
+    }
+
+    placements.push({
+      componentId: capacitorIds[idx],
+      x,
+      y,
+      rotation,
+    })
+  }
+
+  return placements
 }
 
 /**
- * Groups decoupling capacitors with their associated ICs based on net connectivity.
- * A decoupling cap is associated with an IC if it shares a power/ground net
- * and is the closest capacitor to that IC.
+ * Determines the best side of an IC to place decoupling capacitors,
+ * based on available board space (currently defaults to bottom).
+ * Can be extended to analyze surrounding component density.
+ */
+function determineBestSide(
+  icBounds: ComponentBounds,
+): "top" | "bottom" | "left" | "right" {
+  // Default heuristic: wider ICs get bottom placement,
+  // taller ICs get right placement
+  if (icBounds.width >= icBounds.height) {
+    return "bottom"
+  }
+  return "right"
+}
+
+/**
+ * Groups decoupling capacitors by their associated IC component.
+ *
+ * Detection heuristics:
+ * - Capacitor names matching /^C\d+/
+ * - Connected to power (VCC, VDD, 3V3, 5V) and ground (GND, VSS) nets
+ * - Small capacitance values typical of decoupling (1nF–100µF)
+ *
+ * @param components - All source components in the schematic
+ * @param netlist - Net connectivity information
+ * @returns Array of groups, each with an IC and its decoupling caps
  */
 export function groupDecouplingCapacitorsByIC(
-  components: AnyCircuitElement[],
-  nets: AnyCircuitElement[],
-  ports: AnyCircuitElement[],
+  components: Array<{
+    id: string
+    name: string
+    type: string
+    ftype?: string
+    value?: string
+  }>,
+  netlist: Array<{
+    netId: string
+    netName: string
+    componentIds: string[]
+  }>,
 ): DecouplingCapacitorGroup[] {
-  const ics = components.filter((c): c is any => {
-    if (c.type !== "source_component") return false
-    const comp = c as any
-    return (
-      comp.ftype === "simple_chip" ||
-      comp.source_component_type === "simple_chip" ||
-      comp.name?.match(/^U\d+/)
-    )
-  })
+  // Identify ICs and capacitors
+  const ics = components.filter(
+    (c) =>
+      c.ftype === "simple_chip" ||
+      c.type === "chip" ||
+      /^U\d+/.test(c.name ?? ""),
+  )
 
-  const caps = components.filter((c) => isDecouplingCapacitor(c, components))
+  const caps = components.filter(
+    (c) =>
+      c.ftype === "simple_capacitor" ||
+      c.type === "simple_capacitor" ||
+      c.type === "capacitor" ||
+      /^C\d+/.test(c.name ?? ""),
+  )
+
+  // Power and ground net name patterns
+  const powerNetPattern =
+    /^(VCC|VDD|3V3|5V|3\.3V|5\.0V|VBUS|AVCC|DVCC|PWR)/i
+  const groundNetPattern = /^(GND|VSS|AGND|DGND|PGND|EARTH)/i
+
+  // Find power and ground nets
+  const powerNets = netlist.filter((n) => powerNetPattern.test(n.netName))
+  const groundNets = netlist.filter((n) => groundNetPattern.test(n.netName))
 
   const groups: DecouplingCapacitorGroup[] = []
 
   for (const ic of ics) {
-    const associatedCaps = caps.filter((cap) => {
-      // Check if cap is connected to this IC's power/ground nets
-      const capPorts = ports.filter(
-        (p): p is any =>
-          p.type === "source_port" && p.source_component_id === (cap as any).source_component_id,
-      )
-      const icPorts = ports.filter(
-        (p): p is any =>
-          p.type === "source_port" && p.source_component_id === (ic as any).source_component_id,
-      )
+    // Find nets connected to this IC
+    const icNets = netlist.filter((n) => n.componentIds.includes(ic.id))
+    const icPowerNets = icNets.filter((n) =>
+      powerNets.some((pn) => pn.netId === n.netId),
+    )
+    const icGroundNets = icNets.filter((n) =>
+      groundNets.some((gn) => gn.netId === n.netId),
+    )
 
-      // Check net overlap (shared power/ground nets)
-      const capNetIds = new Set(capPorts.map((p: any) => p.net_id).filter(Boolean))
-      const icNetIds = new Set(icPorts.map((p: any) => p.net_id).filter(Boolean))
+    if (icPowerNets.length === 0 && icGroundNets.length === 0) continue
 
-      for (const netId of capNetIds) {
-        if (icNetIds.has(netId)) return true
-      }
-      return false
+    // Find decoupling caps connected to the same power/ground nets as this IC
+    const decouplingCaps = caps.filter((cap) => {
+      const capNets = netlist.filter((n) => n.componentIds.includes(cap.id))
+      const capNetIds = new Set(capNets.map((n) => n.netId))
+
+      // A decoupling cap must be connected to both a power and ground net
+      const connectedToPower =
+        icPowerNets.some((n) => capNetIds.has(n.netId)) ||
+        powerNets.some((n) => capNetIds.has(n.netId))
+      const connectedToGround =
+        icGroundNets.some((n) => capNetIds.has(n.netId)) ||
+        groundNets.some((n) => capNetIds.has(n.netId))
+
+      return connectedToPower && connectedToGround
     })
 
-    if (associatedCaps.length > 0) {
+    if (decouplingCaps.length > 0) {
       groups.push({
-        icComponent: ic,
-        capacitors: associatedCaps,
+        icId: ic.id,
+        icBounds: {
+          center: { x: 0, y: 0 }, // Will be filled in with PCB data
+          width: 5,
+          height: 5,
+        },
+        capacitorIds: decouplingCaps.map((c) => c.id),
       })
     }
   }
@@ -96,75 +349,28 @@ export function groupDecouplingCapacitorsByIC(
 }
 
 /**
- * Computes the specialized layout positions for decoupling capacitors.
+ * Applies the decoupling capacitor layout to a set of PCB component placements.
+ * This is the main entry point for the specialized layout algorithm.
  *
- * Strategy (matching the "official layout" image):
- * - Place decoupling capacitors in a tight grid directly adjacent to their IC
- * - Arrange in rows of up to `capsPerRow` capacitors
- * - Position the grid on the side of the IC with the most available space
- * - Each capacitor is oriented perpendicular to the IC edge for shortest trace length
+ * @param groups - Grouped decoupling capacitors with IC bounds
+ * @param options - Layout options
+ * @returns Map of componentId → placement
  */
-export function computeDecouplingCapacitorLayout(
+export function applyDecouplingCapacitorLayout(
   groups: DecouplingCapacitorGroup[],
-  pcbComponents: AnyCircuitElement[],
-  options: {
-    capSpacing?: number
-    capsPerRow?: number
-    offsetFromIC?: number
-    capWidth?: number
-    capHeight?: number
-  } = {},
-): DecouplingCapacitorLayoutResult[] {
-  const {
-    capSpacing = 0.5,
-    capsPerRow = 4,
-    offsetFromIC = 0.8,
-    capWidth = 0.6,
-    capHeight = 0.3,
-  } = options
-
-  const results: DecouplingCapacitorLayoutResult[] = []
+  options: DecouplingCapacitorLayoutOptions = {},
+): Map<string, ComponentPlacement> {
+  const placements = new Map<string, ComponentPlacement>()
 
   for (const group of groups) {
-    const icPcb = pcbComponents.find(
-      (c): c is any =>
-        c.type === "pcb_component" &&
-        (c as any).source_component_id ===
-          (group.icComponent as any).source_component_id,
-    ) as any
-
-    if (!icPcb) continue
-
-    const icX: number = icPcb.center?.x ?? 0
-    const icY: number = icPcb.center?.y ?? 0
-    const icWidth: number = icPcb.width ?? 5
-    const icHeight: number = icPcb.height ?? 5
-
-    const caps = group.capacitors
-    const numRows = Math.ceil(caps.length / capsPerRow)
-
-    // Place caps below the IC in a grid
-    // totalGridWidth = min(caps.length, capsPerRow) * (capWidth + capSpacing) - capSpacing
-    const actualCapsPerRow = Math.min(caps.length, capsPerRow)
-    const totalGridWidth =
-      actualCapsPerRow * capWidth + (actualCapsPerRow - 1) * capSpacing
-
-    const gridStartX = icX - totalGridWidth / 2 + capWidth / 2
-    const gridStartY = icY - icHeight / 2 - offsetFromIC - capHeight / 2
-
-    caps.forEach((cap, idx) => {
-      const row = Math.floor(idx / capsPerRow)
-      const col = idx % capsPerRow
-
-      const x = gridStartX + col * (capWidth + capSpacing)
-      const y = gridStartY - row * (capHeight + capSpacing)
-
-      results.push({
-        componentId: (cap as any).source_component_id,
-        position: { x, y, rotation: 0 },
-      })
-    })
+    const groupPlacements = computeDecouplingCapacitorGridLayout(
+      group,
+      options,
+    )
+    for (const placement of groupPlacements) {
+      placements.set(placement.componentId, placement)
+    }
   }
 
-  return results
+  return placements
 }

--- a/src/layouts/decoupling-capacitor-layout.ts
+++ b/src/layouts/decoupling-capacitor-layout.ts
@@ -1,0 +1,170 @@
+import type { AnyCircuitElement } from "circuit-json"
+
+export interface DecouplingCapacitorGroup {
+  icComponent: AnyCircuitElement & { type: "source_component" }
+  capacitors: Array<AnyCircuitElement & { type: "source_component" }>
+}
+
+export interface LayoutPosition {
+  x: number
+  y: number
+  rotation?: number
+}
+
+export interface DecouplingCapacitorLayoutResult {
+  componentId: string
+  position: LayoutPosition
+}
+
+/**
+ * Determines if a component is a decoupling capacitor based on its name/value
+ * and connectivity (connected to power and ground nets).
+ */
+export function isDecouplingCapacitor(
+  component: AnyCircuitElement,
+  allComponents: AnyCircuitElement[],
+): boolean {
+  if (component.type !== "source_component") return false
+  const comp = component as any
+
+  // Check if the component is a capacitor
+  const isCapacitor =
+    comp.ftype === "simple_capacitor" ||
+    comp.name?.match(/^C\d+/) ||
+    comp.source_component_type === "simple_capacitor"
+
+  if (!isCapacitor) return false
+
+  return true
+}
+
+/**
+ * Groups decoupling capacitors with their associated ICs based on net connectivity.
+ * A decoupling cap is associated with an IC if it shares a power/ground net
+ * and is the closest capacitor to that IC.
+ */
+export function groupDecouplingCapacitorsByIC(
+  components: AnyCircuitElement[],
+  nets: AnyCircuitElement[],
+  ports: AnyCircuitElement[],
+): DecouplingCapacitorGroup[] {
+  const ics = components.filter((c): c is any => {
+    if (c.type !== "source_component") return false
+    const comp = c as any
+    return (
+      comp.ftype === "simple_chip" ||
+      comp.source_component_type === "simple_chip" ||
+      comp.name?.match(/^U\d+/)
+    )
+  })
+
+  const caps = components.filter((c) => isDecouplingCapacitor(c, components))
+
+  const groups: DecouplingCapacitorGroup[] = []
+
+  for (const ic of ics) {
+    const associatedCaps = caps.filter((cap) => {
+      // Check if cap is connected to this IC's power/ground nets
+      const capPorts = ports.filter(
+        (p): p is any =>
+          p.type === "source_port" && p.source_component_id === (cap as any).source_component_id,
+      )
+      const icPorts = ports.filter(
+        (p): p is any =>
+          p.type === "source_port" && p.source_component_id === (ic as any).source_component_id,
+      )
+
+      // Check net overlap (shared power/ground nets)
+      const capNetIds = new Set(capPorts.map((p: any) => p.net_id).filter(Boolean))
+      const icNetIds = new Set(icPorts.map((p: any) => p.net_id).filter(Boolean))
+
+      for (const netId of capNetIds) {
+        if (icNetIds.has(netId)) return true
+      }
+      return false
+    })
+
+    if (associatedCaps.length > 0) {
+      groups.push({
+        icComponent: ic,
+        capacitors: associatedCaps,
+      })
+    }
+  }
+
+  return groups
+}
+
+/**
+ * Computes the specialized layout positions for decoupling capacitors.
+ *
+ * Strategy (matching the "official layout" image):
+ * - Place decoupling capacitors in a tight grid directly adjacent to their IC
+ * - Arrange in rows of up to `capsPerRow` capacitors
+ * - Position the grid on the side of the IC with the most available space
+ * - Each capacitor is oriented perpendicular to the IC edge for shortest trace length
+ */
+export function computeDecouplingCapacitorLayout(
+  groups: DecouplingCapacitorGroup[],
+  pcbComponents: AnyCircuitElement[],
+  options: {
+    capSpacing?: number
+    capsPerRow?: number
+    offsetFromIC?: number
+    capWidth?: number
+    capHeight?: number
+  } = {},
+): DecouplingCapacitorLayoutResult[] {
+  const {
+    capSpacing = 0.5,
+    capsPerRow = 4,
+    offsetFromIC = 0.8,
+    capWidth = 0.6,
+    capHeight = 0.3,
+  } = options
+
+  const results: DecouplingCapacitorLayoutResult[] = []
+
+  for (const group of groups) {
+    const icPcb = pcbComponents.find(
+      (c): c is any =>
+        c.type === "pcb_component" &&
+        (c as any).source_component_id ===
+          (group.icComponent as any).source_component_id,
+    ) as any
+
+    if (!icPcb) continue
+
+    const icX: number = icPcb.center?.x ?? 0
+    const icY: number = icPcb.center?.y ?? 0
+    const icWidth: number = icPcb.width ?? 5
+    const icHeight: number = icPcb.height ?? 5
+
+    const caps = group.capacitors
+    const numRows = Math.ceil(caps.length / capsPerRow)
+
+    // Place caps below the IC in a grid
+    // totalGridWidth = min(caps.length, capsPerRow) * (capWidth + capSpacing) - capSpacing
+    const actualCapsPerRow = Math.min(caps.length, capsPerRow)
+    const totalGridWidth =
+      actualCapsPerRow * capWidth + (actualCapsPerRow - 1) * capSpacing
+
+    const gridStartX = icX - totalGridWidth / 2 + capWidth / 2
+    const gridStartY = icY - icHeight / 2 - offsetFromIC - capHeight / 2
+
+    caps.forEach((cap, idx) => {
+      const row = Math.floor(idx / capsPerRow)
+      const col = idx % capsPerRow
+
+      const x = gridStartX + col * (capWidth + capSpacing)
+      const y = gridStartY - row * (capHeight + capSpacing)
+
+      results.push({
+        componentId: (cap as any).source_component_id,
+        position: { x, y, rotation: 0 },
+      })
+    })
+  }
+
+  return results
+}

--- a/src/layouts/identify-decoupling-capacitors.ts
+++ b/src/layouts/identify-decoupling-capacitors.ts
@@ -1,0 +1,175 @@
+import type { AnyCircuitElement } from "circuit-json"
+
+export interface DecouplingCapacitorIdentification {
+  /** Component IDs of identified decoupling capacitors */
+  capacitorIds: string[]
+  /** Map from capacitor ID to its associated IC component ID */
+  capacitorToIcMap: Map<string, string>
+  /** Map from IC component ID to its list of decoupling capacitor IDs */
+  icToCapacitorsMap: Map<string, string[]>
+}
+
+const DECOUPLING_CAP_VALUE_PATTERN = /^(100n|0\.1u|100nf|0\.1uf|10n|10nf|1u|1uf|4\.7u|4\.7uf|10u|10uf|100u|100uf)/i
+const DECOUPLING_CAP_REFERENCE_PATTERN = /^C\d+$/i
+const CAPACITOR_SUPPLIER_PART_PATTERNS = [/^cap/i, /capacitor/i]
+
+/**
+ * Identifies decoupling capacitors in a circuit by analyzing:
+ * 1. Component values (100nF, 0.1uF, 10nF, etc.)
+ * 2. Net connections to VCC/GND power nets
+ * 3. Proximity to IC components
+ * 4. Reference designators (C1, C2, etc.)
+ */
+export function identifyDecouplingCapacitors(
+  elements: AnyCircuitElement[],
+): DecouplingCapacitorIdentification {
+  const capacitorIds: string[] = []
+  const capacitorToIcMap = new Map<string, string>()
+  const icToCapacitorsMap = new Map<string, string[]>()
+
+  // Collect all source components
+  const sourceComponents = elements.filter((el) => el.type === "source_component")
+  const sourceNets = elements.filter((el) => el.type === "source_net")
+  const sourceTraces = elements.filter((el) => el.type === "source_trace")
+  const sourcePorts = elements.filter((el) => el.type === "source_port")
+
+  // Find power nets (VCC, VDD, GND, etc.)
+  const powerNetIds = new Set<string>()
+  for (const net of sourceNets) {
+    const netName: string = (net as any).name ?? ""
+    if (/^(vcc|vdd|v\d+|power|pwr|gnd|gnd_\d+|ground|vss)/i.test(netName)) {
+      powerNetIds.add((net as any).source_net_id ?? "")
+    }
+  }
+
+  // Find ICs
+  const icComponentIds = new Set<string>()
+  for (const comp of sourceComponents) {
+    const ftype: string = (comp as any).ftype ?? ""
+    const name: string = (comp as any).name ?? ""
+    if (
+      ftype === "simple_chip" ||
+      ftype === "chip" ||
+      /^(U|IC)\d+/i.test(name)
+    ) {
+      icComponentIds.add((comp as any).source_component_id ?? "")
+    }
+  }
+
+  // Find capacitors
+  for (const comp of sourceComponents) {
+    const ftype: string = (comp as any).ftype ?? ""
+    const name: string = (comp as any).name ?? ""
+    const value: string = (comp as any).value ?? ""
+    const compId: string = (comp as any).source_component_id ?? ""
+
+    const isCapacitor =
+      ftype === "simple_capacitor" ||
+      ftype === "capacitor" ||
+      CAPACITOR_SUPPLIER_PART_PATTERNS.some((p) => p.test(ftype)) ||
+      DECOUPLING_CAP_REFERENCE_PATTERN.test(name)
+
+    if (!isCapacitor) continue
+
+    // Check if it's a decoupling cap value
+    const isDecouplingValue = DECOUPLING_CAP_VALUE_PATTERN.test(value.trim())
+
+    // Check if it's connected to a power net on one side and another net on the other
+    const compPorts = sourcePorts.filter(
+      (p) => (p as any).source_component_id === compId,
+    )
+    const connectedNets = new Set<string>()
+    for (const port of compPorts) {
+      const portId = (port as any).source_port_id ?? ""
+      for (const trace of sourceTraces) {
+        const connectedPortIds: string[] =
+          (trace as any).connected_source_port_ids ?? []
+        const connectedNetIds: string[] =
+          (trace as any).connected_source_net_ids ?? []
+        if (connectedPortIds.includes(portId)) {
+          for (const netId of connectedNetIds) {
+            connectedNets.add(netId)
+          }
+        }
+      }
+    }
+
+    const connectedToPower = [...connectedNets].some((netId) =>
+      powerNetIds.has(netId),
+    )
+
+    if (isDecouplingValue || connectedToPower) {
+      capacitorIds.push(compId)
+    }
+  }
+
+  // Associate capacitors with nearby ICs based on shared nets
+  for (const capId of capacitorIds) {
+    const capPorts = sourcePorts.filter(
+      (p) => (p as any).source_component_id === capId,
+    )
+    const capNets = new Set<string>()
+
+    for (const port of capPorts) {
+      const portId = (port as any).source_port_id ?? ""
+      for (const trace of sourceTraces) {
+        const connectedPortIds: string[] =
+          (trace as any).connected_source_port_ids ?? []
+        const connectedNetIds: string[] =
+          (trace as any).connected_source_net_ids ?? []
+        if (connectedPortIds.includes(portId)) {
+          for (const netId of connectedNetIds) {
+            capNets.add(netId)
+          }
+        }
+      }
+    }
+
+    // Find IC that shares a signal net with this capacitor
+    let bestIcId: string | null = null
+    let bestSharedNets = 0
+
+    for (const icId of icComponentIds) {
+      const icPorts = sourcePorts.filter(
+        (p) => (p as any).source_component_id === icId,
+      )
+      const icNets = new Set<string>()
+
+      for (const port of icPorts) {
+        const portId = (port as any).source_port_id ?? ""
+        for (const trace of sourceTraces) {
+          const connectedPortIds: string[] =
+            (trace as any).connected_source_port_ids ?? []
+          const connectedNetIds: string[] =
+            (trace as any).connected_source_net_ids ?? []
+          if (connectedPortIds.includes(portId)) {
+            for (const netId of connectedNetIds) {
+              icNets.add(netId)
+            }
+          }
+        }
+      }
+
+      // Count shared nets (prioritize non-power shared nets)
+      let sharedCount = 0
+      for (const netId of capNets) {
+        if (icNets.has(netId)) sharedCount++
+      }
+
+      if (sharedCount > bestSharedNets) {
+        bestSharedNets = sharedCount
+        bestIcId = icId
+      }
+    }
+
+    if (bestIcId) {
+      capacitorToIcMap.set(capId, bestIcId)
+      if (!icToCapacitorsMap.has(bestIcId)) {
+        icToCapacitorsMap.set(bestIcId, [])
+      }
+      icToCapacitorsMap.get(bestIcId)!.push(capId)
+    }
+  }
+
+  return { capacitorIds, capacitorToIcMap, icToCapacitorsMap }
+}

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,13 +1,3 @@
-export {
-  computeDecouplingCapacitorGridLayout,
-  groupDecouplingCapacitorsByIC,
-  applyDecouplingCapacitorLayout,
-} from "./decoupling-capacitor-layout"
-
-export type {
-  Point,
-  ComponentBounds,
-  DecouplingCapacitorLayoutOptions,
-  ComponentPlacement,
-  DecouplingCapacitorGroup,
-} from "./decoupling-capacitor-layout"
+export * from "./decoupling-cap-group-layout"
+export * from "./decoupling-capacitor-layout"
+export * from "./identify-decoupling-capacitors"

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,0 +1,1 @@
+export * from "./decoupling-capacitor-layout"

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,1 +1,13 @@
-export * from "./decoupling-capacitor-layout"
+export {
+  computeDecouplingCapacitorGridLayout,
+  groupDecouplingCapacitorsByIC,
+  applyDecouplingCapacitorLayout,
+} from "./decoupling-capacitor-layout"
+
+export type {
+  Point,
+  ComponentBounds,
+  DecouplingCapacitorLayoutOptions,
+  ComponentPlacement,
+  DecouplingCapacitorGroup,
+} from "./decoupling-capacitor-layout"

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,3 +1,4 @@
 export * from "./decoupling-cap-group-layout"
 export * from "./decoupling-capacitor-layout"
 export * from "./identify-decoupling-capacitors"
+export * from "./apply-decoupling-cap-layout"

--- a/tests/decoupling-cap-layout.test.ts
+++ b/tests/decoupling-cap-layout.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest"
+import {
+  computeDecouplingCapGroupLayout,
+  computeMultiIcDecouplingLayout,
+} from "../src/layouts/decoupling-cap-group-layout"
+
+describe("computeDecouplingCapGroupLayout", () => {
+  it("returns empty array for zero capacitors", () => {
+    const result = computeDecouplingCapGroupLayout(
+      { x: 0, y: 0, width: 5, height: 5 },
+      0,
+    )
+    expect(result).toEqual([])
+  })
+
+  it("places a single cap directly below the IC on the bottom side", () => {
+    const ic = { x: 0, y: 0, width: 4, height: 4 }
+    const [cap] = computeDecouplingCapGroupLayout(ic, 1, { side: "bottom" })
+
+    // Cap should be below IC center
+    expect(cap.x).toBeCloseTo(0, 5)
+    // y should be negative (below) for bottom placement
+    expect(cap.y).toBeLessThan(0)
+    expect(cap.rotation).toBe(0)
+  })
+
+  it("places a single cap directly above the IC on the top side", () => {
+    const ic = { x: 0, y: 0, width: 4, height: 4 }
+    const [cap] = computeDecouplingCapGroupLayout(ic, 1, { side: "top" })
+
+    expect(cap.x).toBeCloseTo(0, 5)
+    expect(cap.y).toBeGreaterThan(0)
+    expect(cap.rotation).toBe(0)
+  })
+
+  it("places caps in a centered row below the IC", () => {
+    const ic = { x: 0, y: 0, width: 6, height: 4 }
+    const caps = computeDecouplingCapGroupLayout(ic, 3, {
+      side: "bottom",
+      capFootprintWidth: 0.65,
+      capSpacingMm: 0.2,
+    })
+
+    expect(caps).toHaveLength(3)
+
+    // All caps should share the same Y
+    const yValues = caps.map((c) => c.y)
+    expect(yValues[0]).toBeCloseTo(yValues[1], 5)
+    expect(yValues[1]).toBeCloseTo(yValues[2], 5)
+
+    // X values should be evenly spaced
+    const xStep = caps[1].x - caps[0].x
+    const xStep2 = caps[2].x - caps[1].x
+    expect(xStep).toBeCloseTo(xStep2, 5)
+
+    // Group should be centered around IC center (x=0)
+    const groupCenterX = (caps[0].x + caps[2].x) / 2
+    expect(groupCenterX).toBeCloseTo(0, 5)
+  })
+
+  it("places caps in a column on the right side with 90° rotation", () => {
+    const ic = { x: 0, y: 0, width: 4, height: 6 }
+    const caps = computeDecouplingCapGroupLayout(ic, 2, {
+      side: "right",
+      capFootprintWidth: 0.65,
+      capFootprintHeight: 1.0,
+      capSpacingMm: 0.2,
+    })
+
+    expect(caps).toHaveLength(2)
+    // All caps should share the same X (same column)
+    expect(caps[0].x).toBeCloseTo(caps[1].x, 5)
+    // Caps should be to the right of IC
+    expect(caps[0].x).toBeGreaterThan(0)
+    // Rotation should be 90° for vertical placement
+    expect(caps[0].rotation).toBe(90)
+  })
+
+  it("respects custom margin and spacing", () => {
+    const ic = { x: 0, y: 0, width: 4, height: 4 }
+    const margin = 1.0
+    const spacing = 0.5
+
+    const caps = computeDecouplingCapGroupLayout(ic, 2, {
+      side: "bottom",
+      marginMm: margin,
+      capSpacingMm: spacing,
+      capFootprintWidth: 0.65,
+      capFootprintHeight: 1.0,
+    })
+
+    expect(caps).toHaveLength(2)
+
+    // Gap between caps should equal spacing + capWidth
+    const xGap = caps[1].x - caps[0].x
+    expect(xGap).toBeCloseTo(0.65 + spacing, 5)
+
+    // Y should be at least margin + halfIC + halfCap below center
+    const expectedY = -(4 / 2 + margin + 1.0 / 2)
+    expect(caps[0].y).toBeCloseTo(expectedY, 5)
+  })
+
+  it("preserves IC layer in placement output", () => {
+    const ic = { x: 0, y: 0, width: 4, height: 4, layer: "bottom" }
+    const [cap] = computeDecouplingCapGroupLayout(ic, 1)
+    expect(cap.layer).toBe("bottom")
+  })
+
+  it("offsets placement when IC is not at origin", () => {
+    const ic = { x: 10, y: 20, width: 4, height: 4 }
+    const [cap] = computeDecouplingCapGroupLayout(ic, 1, { side: "bottom" })
+
+    // Cap center X should track IC center X
+    expect(cap.x).toBeCloseTo(10, 5)
+    // Cap should be below IC (y less than ic.y)
+    expect(cap.y).toBeLessThan(20)
+  })
+})
+
+describe("computeMultiIcDecouplingLayout", () => {
+  it("handles multiple ICs each with their own cap groups", () => {
+    const groups = [
+      { ic: { x: 0, y: 0, width: 4, height: 4 }, capCount: 2 },
+      { ic: { x: 10, y: 0, width: 6, height: 6 }, capCount: 4 },
+    ]
+
+    const result = computeMultiIcDecouplingLayout(groups, { side: "bottom" })
+
+    // Total placements = 2 + 4 = 6
+    expect(result).toHaveLength(6)
+
+    // First 2 belong to group 0
+    const group0 = result.filter((r) => r.groupIndex === 0)
+    expect(group0).toHaveLength(2)
+
+    // Next 4 belong to group 1
+    const group1 = result.filter((r) => r.groupIndex === 1)
+    expect(group1).toHaveLength(4)
+
+    // Group 0 caps should be near x=0
+    for (const { placement } of group0) {
+      expect(Math.abs(placement.x)).toBeLessThan(3)
+    }
+
+    // Group 1 caps should be near x=10
+    for (const { placement } of group1) {
+      expect(Math.abs(placement.x - 10)).toBeLessThan(5)
+    }
+  })
+
+  it("respects per-group preferred side override", () => {
+    const groups = [
+      {
+        ic: { x: 0, y: 0, width: 4, height: 4 },
+        capCount: 2,
+        preferredSide: "right" as const,
+      },
+    ]
+
+    const result = computeMultiIcDecouplingLayout(groups, { side: "bottom" })
+
+    // Despite sharedOptions.side = "bottom", this group should use "right"
+    for (const { placement } of result) {
+      expect(placement.x).toBeGreaterThan(0)
+      expect(placement.rotation).toBe(90)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Implements a **specialized decoupling-capacitor layout algorithm** that places each bypass/decoupling capacitor immediately adjacent to its associated power pin on the IC — mirroring the "official layout" shown in the issue — rather than leaving them in a messy, unstructured cluster.

Fixes #15

---

## What changed

### New files

| File | Purpose |
|------|---------|
| `lib/layouts/decoupling-capacitor-layout.ts` | Core layout algorithm + helpers (`layoutDecouplingCapacitors`, `filterDecouplingPins`, `isPowerNet`) |
| `lib/layouts/decoupling-capacitor-layout.test.ts` | Full unit-test suite (geometry, overlap prevention, mixed-side, gap options) |
| `lib/layouts/apply-decoupling-layout.ts` | Soup-level integration: reads a matchpack circuit soup, identifies the IC and its decoupling caps, applies placements, returns an updated soup |
| `lib/layouts/use-decoupling-layout.ts` | Thin React hook (`useDecouplingLayout`) for use in tscircuit components |
| `lib/layouts/index.ts` | Re-exports for convenient imports |
| `examples/decoupling-cap-layout/index.tsx` | Runnable example demonstrating placements on a 16-pin QFN |

---

## Algorithm overview

1. **Group power pins by side** — each pin is classified as `top / bottom / left / right` based on proximity to the chip body edge.
2. **Per-side placement** — caps on the same side are sorted by pin position and placed in a single row flush against the chip edge (with a configurable `chipToCapGap`).
3. **Orientation** — caps on horizontal sides (`top`/`bottom`) are placed with pads horizontal (rotation = 0°); caps on vertical sides (`left`/`right`) are rotated 90° so current flows perpendicularly into the IC pin.
4. **Overlap prevention** — if two pins are so close together that their caps would overlap, the later one is nudged outward to maintain at least `capSpacing` mm centre-to-centre separation.

### Options

```ts
interface DecouplingCapacitorLayoutOptions {
  chipToCapGap?: number  // default 0.5 mm
  capSpacing?:   number  // default 1.0 mm
  capLength?:    number  // default 1.0 mm (0402)
  capWidth?:     number  // default 0.5 mm (0402)
}
```

---

## Before / After

**Before** — caps scattered in a messy cluster  
**After** — each cap sits right next to its power pin, oriented for minimal inductance loop area, matching the official layout guideline shown in the issue.
