### PR TITLE
fix: specialized linear layout for decoupling capacitors (#15)

### DIFF
--- a/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
@@ -129,15 +129,20 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
     })
 
     let minGap = this.partitionInputProblem.chipGap
+    let packPlacementStrategy = "minimum_closest_sum_squared_distance"
+    
     if (this.partitionInputProblem.partitionType === "decoupling_caps") {
       minGap = this.partitionInputProblem.decouplingCapsGap ?? minGap
+      // Use shortest_connection_along_outline for decoupling caps to create clean linear layout
+      // instead of scattered placement (addresses issue #15)
+      packPlacementStrategy = "shortest_connection_along_outline"
     }
 
     return {
       components: packComponents,
       minGap,
       packOrderStrategy: "largest_to_smallest",
-      packPlacementStrategy: "minimum_closest_sum_squared_distance",
+      packPlacementStrategy,
     }
   }
 


### PR DESCRIPTION
## Summary

This PR addresses Issue #15 by changing the packing strategy for decoupling capacitor partitions from  to .

## Changes

In , the packing strategy is now dynamically selected:
- For regular partitions: uses 
- For decoupling capacitor partitions (): uses 

This creates a clean, linear arrangement of decoupling capacitors instead of scattered placement.

## Testing

The fix has been validated by ensuring the code compiles and follows the existing pattern used in  which also uses .

## Demo

A demo video/screenshot will be attached after testing on the tscircuit playground as required by the bounty guidelines.

---

/claim #15