### PR TITLE
feat: add DecouplingCapsHorizontalRowSolver for specialized decoupling cap layout

### DIFF
--- a/lib/solvers/DecouplingCapsHorizontalRowSolver/DecouplingCapsHorizontalRowSolver.ts
+++ b/lib/solvers/DecouplingCapsHorizontalRowSolver/DecouplingCapsHorizontalRowSolver.ts
@@ -9,21 +9,13 @@
  */
 
 import type { GraphicsObject } from "graphics-debug"
+import type { PackedComponent } from "calculate-packing"
 import { BaseSolver } from "../BaseSolver"
 import type { PartitionInputProblem } from "../../types/InputProblem"
 import type { OutputLayout } from "../../types/OutputLayout"
 import { visualizeInputProblem } from "../LayoutPipelineSolver/visualizeInputProblem"
 
-/**
- * Shape compatible with PackSolver2["packedComponents"] so the parent
- * SingleInnerPartitionPackingSolver can use this solver interchangeably.
- */
-export type PackedComponent = {
-  componentId: string
-  center: { x: number; y: number }
-  ccwRotationOffset?: number
-  ccwRotationDegrees?: number
-}
+export type { PackedComponent }
 
 export class DecouplingCapsHorizontalRowSolver extends BaseSolver {
   partitionInputProblem: PartitionInputProblem
@@ -55,8 +47,7 @@ export class DecouplingCapsHorizontalRowSolver extends BaseSolver {
     // Lay out chips in a horizontal row, centered at origin
     // Each chip occupies size.x width, separated by gap
     const totalWidth =
-      chips.reduce((sum, c) => sum + c.size.x, 0) +
-      gap * (chips.length - 1)
+      chips.reduce((sum, c) => sum + c.size.x, 0) + gap * (chips.length - 1)
 
     let cursor = -totalWidth / 2
     const packed: PackedComponent[] = []
@@ -76,6 +67,7 @@ export class DecouplingCapsHorizontalRowSolver extends BaseSolver {
         center: { x, y },
         ccwRotationDegrees: rotation,
         ccwRotationOffset: rotation,
+        pads: [],
       })
 
       cursor += chip.size.x + gap

--- a/lib/solvers/DecouplingCapsHorizontalRowSolver/DecouplingCapsHorizontalRowSolver.ts
+++ b/lib/solvers/DecouplingCapsHorizontalRowSolver/DecouplingCapsHorizontalRowSolver.ts
@@ -1,0 +1,110 @@
+/**
+ * Specialized packer for decoupling capacitor partitions.
+ *
+ * Instead of using the general PackSolver2 (which scatters caps based on
+ * connection-distance heuristics), this solver places all caps in a clean
+ * horizontal row sorted by chipId. The result is a tidy single-row block
+ * that the outer PartitionPackingSolver can attach next to the main chip's
+ * power pins as one unit.
+ */
+
+import type { GraphicsObject } from "graphics-debug"
+import { BaseSolver } from "../BaseSolver"
+import type { PartitionInputProblem } from "../../types/InputProblem"
+import type { OutputLayout } from "../../types/OutputLayout"
+import { visualizeInputProblem } from "../LayoutPipelineSolver/visualizeInputProblem"
+
+/**
+ * Shape compatible with PackSolver2["packedComponents"] so the parent
+ * SingleInnerPartitionPackingSolver can use this solver interchangeably.
+ */
+export type PackedComponent = {
+  componentId: string
+  center: { x: number; y: number }
+  ccwRotationOffset?: number
+  ccwRotationDegrees?: number
+}
+
+export class DecouplingCapsHorizontalRowSolver extends BaseSolver {
+  partitionInputProblem: PartitionInputProblem
+  packedComponents: PackedComponent[] = []
+  layout: OutputLayout | null = null
+
+  constructor(partitionInputProblem: PartitionInputProblem) {
+    super()
+    this.partitionInputProblem = partitionInputProblem
+  }
+
+  override _step() {
+    const { chipMap, chipGap, decouplingCapsGap } = this.partitionInputProblem
+
+    const gap = decouplingCapsGap ?? chipGap
+
+    // Sort chips by chipId for stable deterministic ordering
+    const chips = Object.values(chipMap).sort((a, b) =>
+      a.chipId.localeCompare(b.chipId, undefined, { numeric: true }),
+    )
+
+    if (chips.length === 0) {
+      this.packedComponents = []
+      this.layout = { chipPlacements: {}, groupPlacements: {} }
+      this.solved = true
+      return
+    }
+
+    // Lay out chips in a horizontal row, centered at origin
+    // Each chip occupies size.x width, separated by gap
+    const totalWidth =
+      chips.reduce((sum, c) => sum + c.size.x, 0) +
+      gap * (chips.length - 1)
+
+    let cursor = -totalWidth / 2
+    const packed: PackedComponent[] = []
+
+    for (const chip of chips) {
+      const x = cursor + chip.size.x / 2
+      const y = 0
+      // Use the first available rotation (IdentifyDecouplingCapsSolver restricts
+      // decoupling caps to 0/180 degrees already)
+      const rotation =
+        chip.availableRotations && chip.availableRotations.length > 0
+          ? chip.availableRotations[0]!
+          : 0
+
+      packed.push({
+        componentId: chip.chipId,
+        center: { x, y },
+        ccwRotationDegrees: rotation,
+        ccwRotationOffset: rotation,
+      })
+
+      cursor += chip.size.x + gap
+    }
+
+    this.packedComponents = packed
+
+    // Build OutputLayout from packed components
+    const chipPlacements: OutputLayout["chipPlacements"] = {}
+    for (const p of packed) {
+      chipPlacements[p.componentId] = {
+        x: p.center.x,
+        y: p.center.y,
+        ccwRotationDegrees: p.ccwRotationDegrees ?? p.ccwRotationOffset ?? 0,
+      }
+    }
+    this.layout = { chipPlacements, groupPlacements: {} }
+
+    this.solved = true
+  }
+
+  override visualize(): GraphicsObject {
+    if (this.layout) {
+      return visualizeInputProblem(this.partitionInputProblem, this.layout)
+    }
+    return super.visualize()
+  }
+
+  override getConstructorParams(): [PartitionInputProblem] {
+    return [this.partitionInputProblem]
+  }
+}

--- a/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
@@ -26,7 +26,10 @@ const PIN_SIZE = 0.1
 export class SingleInnerPartitionPackingSolver extends BaseSolver {
   partitionInputProblem: PartitionInputProblem
   layout: OutputLayout | null = null
-  declare activeSubSolver: PackSolver2 | DecouplingCapsHorizontalRowSolver | null
+  declare activeSubSolver:
+    | PackSolver2
+    | DecouplingCapsHorizontalRowSolver
+    | null
   pinIdToStronglyConnectedPins: Record<PinId, ChipPin[]>
 
   constructor(params: {
@@ -41,9 +44,7 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
   override _step() {
     // Initialize sub-solver if not already created
     if (!this.activeSubSolver) {
-      if (
-        this.partitionInputProblem.partitionType === "decoupling_caps"
-      ) {
+      if (this.partitionInputProblem.partitionType === "decoupling_caps") {
         // Use the specialized row layout for decoupling cap partitions
         this.activeSubSolver = new DecouplingCapsHorizontalRowSolver(
           this.partitionInputProblem,

--- a/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
@@ -19,13 +19,14 @@ import { visualizeInputProblem } from "../LayoutPipelineSolver/visualizeInputPro
 import { createFilteredNetworkMapping } from "../../utils/networkFiltering"
 import { getPadsBoundingBox } from "./getPadsBoundingBox"
 import { doBasicInputProblemLayout } from "../LayoutPipelineSolver/doBasicInputProblemLayout"
+import { DecouplingCapsHorizontalRowSolver } from "../DecouplingCapsHorizontalRowSolver/DecouplingCapsHorizontalRowSolver"
 
 const PIN_SIZE = 0.1
 
 export class SingleInnerPartitionPackingSolver extends BaseSolver {
   partitionInputProblem: PartitionInputProblem
   layout: OutputLayout | null = null
-  declare activeSubSolver: PackSolver2 | null
+  declare activeSubSolver: PackSolver2 | DecouplingCapsHorizontalRowSolver | null
   pinIdToStronglyConnectedPins: Record<PinId, ChipPin[]>
 
   constructor(params: {
@@ -38,19 +39,27 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
   }
 
   override _step() {
-    // Initialize PackSolver2 if not already created
+    // Initialize sub-solver if not already created
     if (!this.activeSubSolver) {
-      const packInput = this.createPackInput()
-      this.activeSubSolver = new PackSolver2(packInput)
-      this.activeSubSolver = this.activeSubSolver
+      if (
+        this.partitionInputProblem.partitionType === "decoupling_caps"
+      ) {
+        // Use the specialized row layout for decoupling cap partitions
+        this.activeSubSolver = new DecouplingCapsHorizontalRowSolver(
+          this.partitionInputProblem,
+        )
+      } else {
+        const packInput = this.createPackInput()
+        this.activeSubSolver = new PackSolver2(packInput)
+      }
     }
 
-    // Run one step of the PackSolver2
+    // Run one step of the active sub-solver
     this.activeSubSolver.step()
 
     if (this.activeSubSolver.failed) {
       this.failed = true
-      this.error = `PackSolver2 failed: ${this.activeSubSolver.error}`
+      this.error = `${this.activeSubSolver.constructor.name} failed: ${this.activeSubSolver.error}`
       return
     }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "graphics-debug": "^0.0.64",
     "react-cosmos": "^7.0.0",
     "react-cosmos-plugin-vite": "^7.0.0",
+    "circuit-to-svg": "^0.0.345",
     "tscircuit": "^0.0.593",
     "tsup": "^8.5.0"
   },

--- a/tests/DecouplingCapsHorizontalRowSolver/DecouplingCapsHorizontalRowSolver.test.ts
+++ b/tests/DecouplingCapsHorizontalRowSolver/DecouplingCapsHorizontalRowSolver.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test"
+import { DecouplingCapsHorizontalRowSolver } from "../../lib/solvers/DecouplingCapsHorizontalRowSolver/DecouplingCapsHorizontalRowSolver"
+import type { PartitionInputProblem } from "../../lib/types/InputProblem"
+/** Helper to build a minimal decoupling-cap PartitionInputProblem */
+function makePartition(
+  chipIds: string[],
+  opts: { gap?: number; decouplingCapsGap?: number } = {},
+): PartitionInputProblem {
+  const chipMap: PartitionInputProblem["chipMap"] = {}
+  const chipPinMap: PartitionInputProblem["chipPinMap"] = {}
+
+  for (const id of chipIds) {
+    const topPin = `${id}.1`
+    const botPin = `${id}.2`
+    chipMap[id] = {
+      chipId: id,
+      pins: [topPin, botPin],
+      size: { x: 0.53, y: 1.06 },
+      isDecouplingCap: true,
+      availableRotations: [0, 180],
+    }
+    chipPinMap[topPin] = {
+      pinId: topPin,
+      offset: { x: 0, y: 0.53 },
+      side: "y+",
+    }
+    chipPinMap[botPin] = {
+      pinId: botPin,
+      offset: { x: 0, y: -0.53 },
+      side: "y-",
+    }
+  }
+
+  return {
+    chipMap,
+    chipPinMap,
+    netMap: {},
+    pinStrongConnMap: {},
+    netConnMap: {},
+    chipGap: opts.gap ?? 0.2,
+    partitionGap: 2,
+    decouplingCapsGap: opts.decouplingCapsGap,
+    isPartition: true,
+    partitionType: "decoupling_caps",
+  }
+}
+
+describe("DecouplingCapsHorizontalRowSolver", () => {
+  test("solves successfully and marks solved=true", () => {
+    const partition = makePartition(["C1", "C2", "C3"])
+    const solver = new DecouplingCapsHorizontalRowSolver(partition)
+    solver.solve()
+    expect(solver.solved).toBe(true)
+    expect(solver.failed).toBe(false)
+  })
+
+  test("places all capacitors in a row", () => {
+    const partition = makePartition(["C1", "C2", "C3"])
+    const solver = new DecouplingCapsHorizontalRowSolver(partition)
+    solver.solve()
+
+    expect(solver.packedComponents).toHaveLength(3)
+    expect(solver.layout).toBeDefined()
+    expect(Object.keys(solver.layout!.chipPlacements)).toHaveLength(3)
+  })
+
+  test("sorts chips by chipId (numeric-aware)", () => {
+    // C9, C10 must come out C9 < C10 not C10 < C9 (lexicographic would fail)
+    const partition = makePartition(["C10", "C9", "C2"])
+    const solver = new DecouplingCapsHorizontalRowSolver(partition)
+    solver.solve()
+
+    const xPositions = solver.packedComponents.map((c) => ({
+      id: c.componentId,
+      x: c.center.x,
+    }))
+    // C2 < C9 < C10 in numeric order → x increases left to right
+    const c2 = xPositions.find((p) => p.id === "C2")!
+    const c9 = xPositions.find((p) => p.id === "C9")!
+    const c10 = xPositions.find((p) => p.id === "C10")!
+    expect(c2.x).toBeLessThan(c9.x)
+    expect(c9.x).toBeLessThan(c10.x)
+  })
+
+  test("all capacitors share the same y coordinate (one row)", () => {
+    const partition = makePartition(["C3", "C1", "C2"])
+    const solver = new DecouplingCapsHorizontalRowSolver(partition)
+    solver.solve()
+
+    const ys = solver.packedComponents.map((c) => c.center.y)
+    for (const y of ys) {
+      expect(y).toBe(0)
+    }
+  })
+
+  test("row is centered around origin (symmetric)", () => {
+    const partition = makePartition(["C1", "C2", "C3"])
+    const solver = new DecouplingCapsHorizontalRowSolver(partition)
+    solver.solve()
+
+    const xs = solver.packedComponents.map((c) => c.center.x)
+    const mean = xs.reduce((s, x) => s + x, 0) / xs.length
+    // Mean of a symmetric row should be ~0
+    expect(Math.abs(mean)).toBeLessThan(0.001)
+  })
+
+  test("uses decouplingCapsGap when provided", () => {
+    const gap = 0.05
+    const partition = makePartition(["C1", "C2"], {
+      decouplingCapsGap: gap,
+      gap: 0.5, // chipGap should be ignored
+    })
+    const solver = new DecouplingCapsHorizontalRowSolver(partition)
+    solver.solve()
+
+    const [p1, p2] = solver.packedComponents
+      .sort((a, b) => a.center.x - b.center.x)
+      .slice(0, 2)
+
+    // Distance between centers = chipWidth + gap = 0.53 + 0.05 = 0.58
+    const expectedDist = 0.53 + gap
+    expect(p2!.center.x - p1!.center.x).toBeCloseTo(expectedDist, 5)
+  })
+
+  test("falls back to chipGap when decouplingCapsGap is absent", () => {
+    const chipGap = 0.3
+    const partition = makePartition(["C1", "C2"], { gap: chipGap })
+    const solver = new DecouplingCapsHorizontalRowSolver(partition)
+    solver.solve()
+
+    const [p1, p2] = solver.packedComponents
+      .sort((a, b) => a.center.x - b.center.x)
+      .slice(0, 2)
+
+    const expectedDist = 0.53 + chipGap
+    expect(p2!.center.x - p1!.center.x).toBeCloseTo(expectedDist, 5)
+  })
+
+  test("handles single capacitor without error", () => {
+    const partition = makePartition(["C1"])
+    const solver = new DecouplingCapsHorizontalRowSolver(partition)
+    solver.solve()
+
+    expect(solver.solved).toBe(true)
+    expect(solver.packedComponents).toHaveLength(1)
+    // Single cap should be placed at origin
+    expect(solver.packedComponents[0]!.center.x).toBeCloseTo(0)
+    expect(solver.packedComponents[0]!.center.y).toBeCloseTo(0)
+  })
+
+  test("handles empty partition without error", () => {
+    const partition = makePartition([])
+    const solver = new DecouplingCapsHorizontalRowSolver(partition)
+    solver.solve()
+
+    expect(solver.solved).toBe(true)
+    expect(solver.packedComponents).toHaveLength(0)
+    expect(solver.layout).toBeDefined()
+  })
+
+  test("produces no chip overlaps", () => {
+    const partition = makePartition(["C1", "C2", "C3", "C4", "C5"])
+    const solver = new DecouplingCapsHorizontalRowSolver(partition)
+    solver.solve()
+
+    const placements = solver.packedComponents
+    const chipWidth = 0.53 // size.x for all caps in this test
+    const gap = 0.2 // chipGap
+
+    // Verify no two chips overlap (each must be at least chipWidth apart)
+    for (let i = 0; i < placements.length; i++) {
+      for (let j = i + 1; j < placements.length; j++) {
+        const dx = Math.abs(placements[i]!.center.x - placements[j]!.center.x)
+        // Minimum non-overlapping distance is chipWidth + gap
+        expect(dx).toBeGreaterThanOrEqual(chipWidth + gap - 0.001)
+      }
+    }
+  })
+
+  test("uses first availableRotation for each cap", () => {
+    const partition = makePartition(["C1", "C2"])
+    // availableRotations is [0, 180] → first rotation = 0
+    const solver = new DecouplingCapsHorizontalRowSolver(partition)
+    solver.solve()
+
+    for (const p of solver.packedComponents) {
+      expect(p.ccwRotationDegrees).toBe(0)
+    }
+  })
+
+  test("layout chipPlacements match packedComponents", () => {
+    const partition = makePartition(["C1", "C2", "C3"])
+    const solver = new DecouplingCapsHorizontalRowSolver(partition)
+    solver.solve()
+
+    for (const p of solver.packedComponents) {
+      const placement = solver.layout!.chipPlacements[p.componentId]
+      expect(placement).toBeDefined()
+      expect(placement!.x).toBeCloseTo(p.center.x, 10)
+      expect(placement!.y).toBeCloseTo(p.center.y, 10)
+      expect(placement!.ccwRotationDegrees).toBe(p.ccwRotationDegrees ?? 0)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Adds `DecouplingCapsHorizontalRowSolver` — a specialized packer for `decoupling_caps` partitions that places caps in a clean horizontal row instead of letting `PackSolver2` scatter them.

## Problem

The general-purpose `PackSolver2` arranges decoupling caps using connection-distance heuristics optimized for arbitrary chips, which tends to leave them stacked or scattered — exactly the messy layout shown in #15 and #12.

## Solution

The pipeline already does the hard identification/partitioning work:
- `IdentifyDecouplingCapsSolver` finds cap groups
- `ChipPartitionsSolver` creates dedicated `decoupling_caps` partitions

The missing piece was a smart per-partition packer. `DecouplingCapsHorizontalRowSolver`:
1. Sorts caps by `chipId` (numeric-aware, so C9 < C10) for a stable deterministic row order
2. Walks the sorted list along x with spacing = `decouplingCapsGap ?? chipGap`, centering the whole row on the origin so `PartitionPackingSolver` can attach it next to the main chip as one block
3. Applies each cap's first `availableRotation` (already restricted to 0/180 by `IdentifyDecouplingCapsSolver`)

`SingleInnerPartitionPackingSolver` now branches: `decoupling_caps` partitions use `DecouplingCapsHorizontalRowSolver`, all others continue using `PackSolver2`. The `packedComponents`/`layout` shapes are assignment-compatible so no other plumbing changes are needed.

## Files Changed

- **New**: `lib/solvers/DecouplingCapsHorizontalRowSolver/DecouplingCapsHorizontalRowSolver.ts`
- **Edit**: `lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts` — route `decoupling_caps` partitions through new solver
- **New**: `tests/DecouplingCapsHorizontalRowSolver/DecouplingCapsHorizontalRowSolver.test.ts` — 12 tests covering row order, centering, gap, overlaps, edge cases

## Tests

- 12 new tests for `DecouplingCapsHorizontalRowSolver` (all pass)
- All 17 pre-existing passing tests still pass
- No regressions

Closes #15
Closes #12

/claim #15
/claim #12