### PR TITLE
Add deterministic row layout for decoupling cap partitions

### DIFF
--- a/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
@@ -14,6 +14,7 @@ import type {
   NetId,
   ChipPin,
   PartitionInputProblem,
+  Chip,
 } from "../../types/InputProblem"
 import { visualizeInputProblem } from "../LayoutPipelineSolver/visualizeInputProblem"
 import { createFilteredNetworkMapping } from "../../utils/networkFiltering"
@@ -38,6 +39,13 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
   }
 
   override _step() {
+    if (this.partitionInputProblem.partitionType === "decoupling_caps") {
+      this.layout = this.createDecouplingCapsRowLayout()
+      this.activeSubSolver = null
+      this.solved = true
+      return
+    }
+
     // Initialize PackSolver2 if not already created
     if (!this.activeSubSolver) {
       const packInput = this.createPackInput()
@@ -62,6 +70,58 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
       this.solved = true
       this.activeSubSolver = null
     }
+  }
+
+  private createDecouplingCapsRowLayout(): OutputLayout {
+    const chipPlacements: Record<string, Placement> = {}
+    const gap =
+      this.partitionInputProblem.decouplingCapsGap ??
+      this.partitionInputProblem.chipGap
+    const orderedChips = Object.values(this.partitionInputProblem.chipMap).sort(
+      (a, b) => a.chipId.localeCompare(b.chipId, undefined, { numeric: true }),
+    )
+    const orientedChips = orderedChips.map((chip) => {
+      const rotation = this.getPreferredRotation(chip)
+      const size = this.getChipSizeForRotation(chip, rotation)
+
+      return { chip, rotation, size }
+    })
+    const totalWidth =
+      orientedChips.reduce((sum, { size }) => sum + size.x, 0) +
+      Math.max(0, orientedChips.length - 1) * gap
+    let cursorX = -totalWidth / 2
+
+    for (const { chip, rotation, size } of orientedChips) {
+      cursorX += size.x / 2
+      chipPlacements[chip.chipId] = {
+        x: cursorX,
+        y: 0,
+        ccwRotationDegrees: rotation,
+      }
+      cursorX += size.x / 2 + gap
+    }
+
+    return {
+      chipPlacements,
+      groupPlacements: {},
+    }
+  }
+
+  private getPreferredRotation(chip: Chip): 0 | 90 | 180 | 270 {
+    const rotations = chip.availableRotations ?? [0, 90, 180, 270]
+    if (rotations.includes(0)) return 0
+    return rotations[0] ?? 0
+  }
+
+  private getChipSizeForRotation(
+    chip: Chip,
+    rotation: 0 | 90 | 180 | 270,
+  ): { x: number; y: number } {
+    if (rotation === 90 || rotation === 270) {
+      return { x: chip.size.y, y: chip.size.x }
+    }
+
+    return chip.size
   }
 
   private createPackInput(): PackInput {

--- a/pages/LayoutPipelineSolver/LayoutPipelineSolver06.page.tsx
+++ b/pages/LayoutPipelineSolver/LayoutPipelineSolver06.page.tsx
@@ -1,6 +1,12 @@
 import type { PackInput } from "calculate-packing"
-import { LayoutPipelineDebugger } from "lib/components/LayoutPipelineDebugger"
 import type { InputProblem } from "lib/index"
+import { Suspense, lazy } from "react"
+
+const LayoutPipelineDebugger = lazy(() =>
+  import("lib/components/LayoutPipelineDebugger").then((module) => ({
+    default: module.LayoutPipelineDebugger,
+  })),
+)
 
 export const problem: InputProblem = {
   chipMap: {
@@ -877,5 +883,9 @@ export const problem: InputProblem = {
 }
 
 export default function LayoutPipelineSolver06Page() {
-  return <LayoutPipelineDebugger problem={problem} />
+  return (
+    <Suspense fallback={null}>
+      <LayoutPipelineDebugger problem={problem} />
+    </Suspense>
+  )
 }

--- a/tests/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.test.ts
+++ b/tests/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "bun:test"
+import { SingleInnerPartitionPackingSolver } from "../../lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver"
+import type {
+  Chip,
+  ChipId,
+  PartitionInputProblem,
+} from "../../lib/types/InputProblem"
+import type { OutputLayout } from "../../lib/types/OutputLayout"
+
+const makeCap = (
+  chipId: ChipId,
+  size: { x: number; y: number },
+  availableRotations: Chip["availableRotations"] = [0, 180],
+): Chip => ({
+  chipId,
+  pins: [],
+  size,
+  isDecouplingCap: true,
+  availableRotations,
+})
+
+const makeDecouplingCapsPartition = (
+  chipMap: Record<ChipId, Chip>,
+  decouplingCapsGap = 0.4,
+): PartitionInputProblem => ({
+  chipMap,
+  chipPinMap: {},
+  netMap: {},
+  pinStrongConnMap: {},
+  netConnMap: {},
+  chipGap: 0.2,
+  partitionGap: 2,
+  decouplingCapsGap,
+  isPartition: true,
+  partitionType: "decoupling_caps",
+})
+
+const getBounds = (
+  inputProblem: PartitionInputProblem,
+  layout: OutputLayout,
+  chipId: ChipId,
+) => {
+  const chip = inputProblem.chipMap[chipId]!
+  const placement = layout.chipPlacements[chipId]!
+  const rotation = placement.ccwRotationDegrees % 180
+  const width = rotation === 90 ? chip.size.y : chip.size.x
+  const height = rotation === 90 ? chip.size.x : chip.size.y
+
+  return {
+    left: placement.x - width / 2,
+    right: placement.x + width / 2,
+    top: placement.y + height / 2,
+    bottom: placement.y - height / 2,
+  }
+}
+
+test("SingleInnerPartitionPackingSolver packs decoupling caps into a deterministic row", () => {
+  const inputProblem = makeDecouplingCapsPartition({
+    C10: makeCap("C10", { x: 0.75, y: 1 }),
+    C1: makeCap("C1", { x: 0.5, y: 1 }),
+    C2: makeCap("C2", { x: 1, y: 1 }),
+  })
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: inputProblem,
+    pinIdToStronglyConnectedPins: {},
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.layout).not.toBeNull()
+  expect(Object.keys(solver.layout!.chipPlacements)).toEqual([
+    "C1",
+    "C2",
+    "C10",
+  ])
+  expect(solver.layout!.chipPlacements.C1!.x).toBeCloseTo(-1.275, 6)
+  expect(solver.layout!.chipPlacements.C2!.x).toBeCloseTo(-0.125, 6)
+  expect(solver.layout!.chipPlacements.C10!.x).toBeCloseTo(1.15, 6)
+  expect(solver.layout!.chipPlacements.C1!.y).toBe(0)
+  expect(solver.layout!.chipPlacements.C2!.y).toBe(0)
+  expect(solver.layout!.chipPlacements.C10!.y).toBe(0)
+
+  const c1Bounds = getBounds(inputProblem, solver.layout!, "C1")
+  const c2Bounds = getBounds(inputProblem, solver.layout!, "C2")
+  const c10Bounds = getBounds(inputProblem, solver.layout!, "C10")
+
+  expect(c2Bounds.left - c1Bounds.right).toBeCloseTo(0.4, 6)
+  expect(c10Bounds.left - c2Bounds.right).toBeCloseTo(0.4, 6)
+})
+
+test("SingleInnerPartitionPackingSolver respects fixed rotated cap dimensions", () => {
+  const inputProblem = makeDecouplingCapsPartition(
+    {
+      C1: makeCap("C1", { x: 1, y: 2 }, [90]),
+      C2: makeCap("C2", { x: 1, y: 1 }, [0]),
+    },
+    0.25,
+  )
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: inputProblem,
+    pinIdToStronglyConnectedPins: {},
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.layout!.chipPlacements.C1!.ccwRotationDegrees).toBe(90)
+  expect(solver.layout!.chipPlacements.C2!.ccwRotationDegrees).toBe(0)
+  expect(solver.layout!.chipPlacements.C1!.x).toBeCloseTo(-0.625, 6)
+  expect(solver.layout!.chipPlacements.C2!.x).toBeCloseTo(1.125, 6)
+
+  const c1Bounds = getBounds(inputProblem, solver.layout!, "C1")
+  const c2Bounds = getBounds(inputProblem, solver.layout!, "C2")
+
+  expect(c2Bounds.left - c1Bounds.right).toBeCloseTo(0.25, 6)
+})


### PR DESCRIPTION
## Summary
- add a focused `decoupling_caps` path in `SingleInnerPartitionPackingSolver` that bypasses generic packing
- place caps in a deterministic centered row using `decouplingCapsGap ?? chipGap` and natural chip-id ordering
- preserve fixed rotations and account for 90/270 degree dimensions when spacing
- add regression tests for ordering, spacing, centering, and rotated dimensions

## Demo
- Short demo video: https://raw.githubusercontent.com/hieu-lee/matchpack/matchpack-82-demo/decoupling-cap-row-demo.mp4
- Preview image: https://raw.githubusercontent.com/hieu-lee/matchpack/matchpack-82-demo/decoupling-cap-row-demo.png
- Raw solver output used for the visual: https://raw.githubusercontent.com/hieu-lee/matchpack/matchpack-82-demo/decoupling-cap-row-demo.json

## Verification
- `npx --yes bun@latest test tests/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.test.ts`
- `npx --yes bun@latest run format:check`
- `npx --yes bun@latest run build`
- `git diff --check`

/claim #15