### PR TITLE
Add deterministic row layout for decoupling capacitors

### DIFF
--- a/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
@@ -38,6 +38,12 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
   }
 
   override _step() {
+    if (this.partitionInputProblem.partitionType === "decoupling_caps") {
+      this.layout = this.createDecouplingCapsRowLayout()
+      this.solved = true
+      return
+    }
+
     // Initialize PackSolver2 if not already created
     if (!this.activeSubSolver) {
       const packInput = this.createPackInput()
@@ -157,6 +163,48 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
           packedComponent.ccwRotationDegrees ||
           0,
       }
+    }
+
+    return {
+      chipPlacements,
+      groupPlacements: {},
+    }
+  }
+
+  private createDecouplingCapsRowLayout(): OutputLayout {
+    const gap =
+      this.partitionInputProblem.decouplingCapsGap ??
+      this.partitionInputProblem.chipGap
+    const chipPlacements: Record<string, Placement> = {}
+    const chipEntries = Object.entries(this.partitionInputProblem.chipMap).sort(
+      ([chipIdA], [chipIdB]) =>
+        chipIdA.localeCompare(chipIdB, undefined, { numeric: true }),
+    )
+
+    const rowItems = chipEntries.map(([chipId, chip]) => {
+      const ccwRotationDegrees = chip.availableRotations?.includes(0)
+        ? 0
+        : (chip.availableRotations?.[0] ?? 0)
+      const rotatedSize =
+        ccwRotationDegrees === 90 || ccwRotationDegrees === 270
+          ? { x: chip.size.y, y: chip.size.x }
+          : chip.size
+
+      return { chipId, ccwRotationDegrees, size: rotatedSize }
+    })
+
+    const totalWidth = rowItems.reduce((width, item, index) => {
+      return width + item.size.x + (index === 0 ? 0 : gap)
+    }, 0)
+
+    let cursorX = -totalWidth / 2
+    for (const item of rowItems) {
+      chipPlacements[item.chipId] = {
+        x: cursorX + item.size.x / 2,
+        y: 0,
+        ccwRotationDegrees: item.ccwRotationDegrees,
+      }
+      cursorX += item.size.x + gap
     }
 
     return {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/bun": "latest",
     "bpc-graph": "^0.0.66",
     "calculate-packing": "^0.0.31",
+    "circuit-to-svg": "^0.0.345",
     "circuit-json": "^0.0.226",
     "graphics-debug": "^0.0.64",
     "react-cosmos": "^7.0.0",

--- a/tests/SingleInnerPartitionPackingSolver/DecouplingCapsRowLayout.test.ts
+++ b/tests/SingleInnerPartitionPackingSolver/DecouplingCapsRowLayout.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "bun:test"
+import { SingleInnerPartitionPackingSolver } from "../../lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver"
+import type { PartitionInputProblem } from "../../lib/types/InputProblem"
+
+const createDecouplingCapPartition = (): PartitionInputProblem => ({
+  isPartition: true,
+  partitionType: "decoupling_caps",
+  chipGap: 0.8,
+  partitionGap: 1,
+  decouplingCapsGap: 0.25,
+  chipMap: {
+    C10: {
+      chipId: "C10",
+      pins: ["C10.1", "C10.2"],
+      size: { x: 0.7, y: 0.3 },
+      availableRotations: [90, 270],
+    },
+    C2: {
+      chipId: "C2",
+      pins: ["C2.1", "C2.2"],
+      size: { x: 0.4, y: 0.2 },
+      availableRotations: [0, 180],
+    },
+    C1: {
+      chipId: "C1",
+      pins: ["C1.1", "C1.2"],
+      size: { x: 0.6, y: 0.25 },
+    },
+  },
+  chipPinMap: {
+    "C1.1": { pinId: "C1.1", offset: { x: -0.2, y: 0 }, side: "x-" },
+    "C1.2": { pinId: "C1.2", offset: { x: 0.2, y: 0 }, side: "x+" },
+    "C2.1": { pinId: "C2.1", offset: { x: -0.15, y: 0 }, side: "x-" },
+    "C2.2": { pinId: "C2.2", offset: { x: 0.15, y: 0 }, side: "x+" },
+    "C10.1": { pinId: "C10.1", offset: { x: -0.1, y: 0 }, side: "x-" },
+    "C10.2": { pinId: "C10.2", offset: { x: 0.1, y: 0 }, side: "x+" },
+  },
+  netMap: {},
+  pinStrongConnMap: {},
+  netConnMap: {},
+})
+
+test("decoupling cap partitions use deterministic centered row layout", () => {
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: createDecouplingCapPartition(),
+    pinIdToStronglyConnectedPins: {},
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.activeSubSolver).toBeUndefined()
+  expect(solver.layout).toBeDefined()
+
+  const placements = solver.layout!.chipPlacements
+  expect(Object.keys(placements)).toEqual(["C1", "C2", "C10"])
+
+  expect(placements.C1!.y).toBe(0)
+  expect(placements.C2!.y).toBe(0)
+  expect(placements.C10!.y).toBe(0)
+
+  expect(placements.C1!.x).toBeLessThan(placements.C2!.x)
+  expect(placements.C2!.x).toBeLessThan(placements.C10!.x)
+
+  expect(placements.C1!.ccwRotationDegrees).toBe(0)
+  expect(placements.C2!.ccwRotationDegrees).toBe(0)
+  expect(placements.C10!.ccwRotationDegrees).toBe(90)
+
+  const leftEdge = placements.C1!.x - 0.6 / 2
+  const rightEdge = placements.C10!.x + 0.3 / 2
+  expect(leftEdge).toBeCloseTo(-rightEdge)
+  expect(placements.C2!.x - placements.C1!.x).toBeCloseTo(
+    0.6 / 2 + 0.25 + 0.4 / 2,
+  )
+  expect(placements.C10!.x - placements.C2!.x).toBeCloseTo(
+    0.4 / 2 + 0.25 + 0.3 / 2,
+  )
+})


### PR DESCRIPTION
## Summary
- add a specialized deterministic row layout for `decoupling_caps` inner partitions
- center capacitors around the origin with `decouplingCapsGap` spacing
- keep natural capacitor ID ordering and prefer zero-degree rotation when available
- add focused coverage for ordering, centering, spacing, and rotation fallback

/claim #15

## Verification
- `bun test tests/SingleInnerPartitionPackingSolver/DecouplingCapsRowLayout.test.ts`
- `bun test tests/ChipPartitionsSolver.test.ts tests/LayoutPipelineSolver/LayoutPipelineSolver03.test.tsx tests/SingleInnerPartitionPackingSolver/DecouplingCapsRowLayout.test.ts`
- `bun test tests/IdentifyDecouplingCapsSolver/IdentifyDecouplingCapsSolver06.test.ts`
- `bun test`
- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

## Note
The earlier `circuit-to-svg` dependency/export failure has been fixed in `872bd29`. The GitHub `test`, `format-check`, and `type-check` checks are now passing; the remaining non-code status is Vercel fork deployment authorization by the `tscircuit` team.