### PR TITLE
Improve decoupling cap main-pin layout

### DIFF
--- a/lib/solvers/ChipPartitionsSolver/ChipPartitionsSolver.ts
+++ b/lib/solvers/ChipPartitionsSolver/ChipPartitionsSolver.ts
@@ -49,7 +49,10 @@ export class ChipPartitionsSolver extends BaseSolver {
 
     // 1) Build decoupling-cap-only partitions (exclude the main chip for each group)
     const decapChipIdSet = new Set<ChipId>()
-    const decapGroupPartitions: ChipId[][] = []
+    const decapGroupPartitions: Array<{
+      chipIds: ChipId[]
+      netPair: [NetId, NetId]
+    }> = []
 
     if (this.decouplingCapGroups && this.decouplingCapGroups.length > 0) {
       for (const group of this.decouplingCapGroups) {
@@ -61,7 +64,10 @@ export class ChipPartitionsSolver extends BaseSolver {
         }
         // Only add a partition if there are at least two caps present in the inputProblem
         if (capsOnly.length >= 2) {
-          decapGroupPartitions.push(capsOnly)
+          decapGroupPartitions.push({
+            chipIds: capsOnly,
+            netPair: group.netPair,
+          })
           // Mark these caps as handled by decoupling-cap partitions
           for (const capId of capsOnly) {
             decapChipIdSet.add(capId)
@@ -119,8 +125,9 @@ export class ChipPartitionsSolver extends BaseSolver {
 
     return [
       ...decapGroupPartitions.map((partition) =>
-        this.createInputProblemFromPartition(partition, inputProblem, {
+        this.createInputProblemFromPartition(partition.chipIds, inputProblem, {
           partitionType: "decoupling_caps",
+          decouplingCapNetPair: partition.netPair,
         }),
       ),
       ...nonDecapPartitions.map((partition) =>
@@ -188,6 +195,7 @@ export class ChipPartitionsSolver extends BaseSolver {
     originalProblem: InputProblem,
     opts?: {
       partitionType?: "default" | "decoupling_caps"
+      decouplingCapNetPair?: [NetId, NetId]
     },
   ): PartitionInputProblem {
     const chipIds = partition
@@ -242,6 +250,19 @@ export class ChipPartitionsSolver extends BaseSolver {
       }
     }
 
+    if (
+      opts?.partitionType === "decoupling_caps" &&
+      opts.decouplingCapNetPair
+    ) {
+      this.addExternalDecouplingNetConnections({
+        originalProblem,
+        relevantPinIds,
+        allowedNetIds: new Set(opts.decouplingCapNetPair),
+        relevantNetIds,
+        netConnMap,
+      })
+    }
+
     for (const netId of relevantNetIds) {
       if (originalProblem.netMap[netId]) {
         netMap[netId] = originalProblem.netMap[netId]
@@ -257,6 +278,55 @@ export class ChipPartitionsSolver extends BaseSolver {
       netConnMap,
       isPartition: true,
       partitionType: opts?.partitionType,
+    }
+  }
+
+  private addExternalDecouplingNetConnections({
+    originalProblem,
+    relevantPinIds,
+    allowedNetIds,
+    relevantNetIds,
+    netConnMap,
+  }: {
+    originalProblem: InputProblem
+    relevantPinIds: Set<PinId>
+    allowedNetIds: Set<NetId>
+    relevantNetIds: Set<NetId>
+    netConnMap: Record<string, boolean>
+  }) {
+    const copyAllowedExternalNets = (
+      targetPinId: PinId,
+      externalPinId: PinId,
+    ) => {
+      for (const [connKey, isConnected] of Object.entries(
+        originalProblem.netConnMap,
+      )) {
+        if (!isConnected) continue
+
+        const [pinId, netId] = connKey.split("-") as [PinId, NetId]
+        if (pinId !== externalPinId || !allowedNetIds.has(netId)) continue
+
+        relevantNetIds.add(netId)
+        netConnMap[`${targetPinId}-${netId}`] = true
+      }
+    }
+
+    for (const [connKey, isConnected] of Object.entries(
+      originalProblem.pinStrongConnMap,
+    )) {
+      if (!isConnected) continue
+
+      const [pin1Id, pin2Id] = connKey.split("-") as [PinId, PinId]
+      const pin1IsRelevant = relevantPinIds.has(pin1Id)
+      const pin2IsRelevant = relevantPinIds.has(pin2Id)
+
+      if (pin1IsRelevant === pin2IsRelevant) continue
+
+      if (pin1IsRelevant) {
+        copyAllowedExternalNets(pin1Id, pin2Id)
+      } else {
+        copyAllowedExternalNets(pin2Id, pin1Id)
+      }
     }
   }
 

--- a/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
@@ -11,6 +11,7 @@ import type {
   InputProblem,
   PinId,
   ChipId,
+  NetId,
   Chip,
   ChipPin,
   PartitionInputProblem,
@@ -124,10 +125,7 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
   private createDecouplingCapsLayout(): OutputLayout {
     const entries = Object.entries(this.partitionInputProblem.chipMap).map(
       ([chipId, chip]) => {
-        const connectedMainPin = this.getStronglyConnectedExternalPin(
-          chipId,
-          chip,
-        )
+        const connectedMainPin = this.getPreferredExternalMainPin(chipId, chip)
         const rotation = getPreferredRotation(chip)
         const layoutSize = this.getChipLayoutSize(chip)
         const rotatedSize = getRotatedSize(layoutSize, rotation)
@@ -230,20 +228,67 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
     return mainPin.offset[sideAwareAxis]
   }
 
-  private getStronglyConnectedExternalPin(
+  private getPreferredExternalMainPin(
     chipId: ChipId,
     chip: Chip,
   ): ChipPin | null {
+    const candidates: Array<{
+      capPinId: PinId
+      externalPin: ChipPin
+      isPositiveVoltage: boolean
+      isGround: boolean
+    }> = []
+
     for (const pinId of chip.pins) {
       for (const connectedPin of this.pinIdToStronglyConnectedPins[pinId] ??
         []) {
         if (getChipIdFromPinId(connectedPin.pinId) !== chipId) {
-          return connectedPin
+          const netRole = this.getPinNetRole(pinId)
+          candidates.push({
+            capPinId: pinId,
+            externalPin: connectedPin,
+            isPositiveVoltage: netRole.isPositiveVoltage,
+            isGround: netRole.isGround,
+          })
         }
       }
     }
 
-    return null
+    candidates.sort((a, b) => {
+      if (a.isPositiveVoltage !== b.isPositiveVoltage) {
+        return a.isPositiveVoltage ? -1 : 1
+      }
+      if (a.isGround !== b.isGround) {
+        return a.isGround ? -1 : 1
+      }
+      const capPinOrder = a.capPinId.localeCompare(b.capPinId)
+      if (capPinOrder !== 0) return capPinOrder
+      return a.externalPin.pinId.localeCompare(b.externalPin.pinId)
+    })
+
+    return candidates[0]?.externalPin ?? null
+  }
+
+  private getPinNetRole(pinId: PinId) {
+    const role = {
+      isPositiveVoltage: false,
+      isGround: false,
+    }
+
+    for (const [connKey, isConnected] of Object.entries(
+      this.partitionInputProblem.netConnMap,
+    )) {
+      if (!isConnected) continue
+
+      const [connectedPinId, netId] = connKey.split("-") as [PinId, NetId]
+      if (connectedPinId !== pinId) continue
+
+      const net = this.partitionInputProblem.netMap[netId]
+      role.isPositiveVoltage ||= Boolean(net?.isPositiveVoltageSource)
+      role.isGround ||= Boolean(net?.isGround)
+    }
+
+    return role
   }
 
   private createPackInput(): PackInput {

--- a/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
@@ -11,7 +11,7 @@ import type {
   InputProblem,
   PinId,
   ChipId,
-  NetId,
+  Chip,
   ChipPin,
   PartitionInputProblem,
 } from "../../types/InputProblem"
@@ -21,6 +21,56 @@ import { getPadsBoundingBox } from "./getPadsBoundingBox"
 import { doBasicInputProblemLayout } from "../LayoutPipelineSolver/doBasicInputProblemLayout"
 
 const PIN_SIZE = 0.1
+
+type LayoutAxis = "x" | "y"
+
+const compareNaturalChipIds = (a: ChipId, b: ChipId) => {
+  const aParts = a.match(/\d+|\D+/g) ?? [a]
+  const bParts = b.match(/\d+|\D+/g) ?? [b]
+  const partCount = Math.min(aParts.length, bParts.length)
+
+  for (let i = 0; i < partCount; i++) {
+    const aPart = aParts[i]!
+    const bPart = bParts[i]!
+    const aNumber = Number(aPart)
+    const bNumber = Number(bPart)
+    const aIsNumber = Number.isInteger(aNumber)
+    const bIsNumber = Number.isInteger(bNumber)
+
+    if (aIsNumber && bIsNumber && aNumber !== bNumber) {
+      return aNumber - bNumber
+    }
+
+    if (aPart !== bPart) {
+      return aPart.localeCompare(bPart)
+    }
+  }
+
+  return aParts.length - bParts.length
+}
+
+const getChipIdFromPinId = (pinId: PinId): ChipId =>
+  pinId.split(".")[0] ?? pinId
+
+const getPreferredRotation = (chip: Chip): 0 | 90 | 180 | 270 => {
+  if (!chip.availableRotations?.length) return 0
+  return chip.availableRotations.includes(0) ? 0 : chip.availableRotations[0]!
+}
+
+const getRotatedSize = (size: { x: number; y: number }, rotation: number) => {
+  if (rotation === 90 || rotation === 270) {
+    return { x: size.y, y: size.x }
+  }
+  return size
+}
+
+const getLayoutAxisForExternalSide = (
+  side: ChipPin["side"] | undefined,
+): LayoutAxis | null => {
+  if (side?.startsWith("x")) return "y"
+  if (side?.startsWith("y")) return "x"
+  return null
+}
 
 export class SingleInnerPartitionPackingSolver extends BaseSolver {
   partitionInputProblem: PartitionInputProblem
@@ -38,6 +88,13 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
   }
 
   override _step() {
+    if (this.partitionInputProblem.partitionType === "decoupling_caps") {
+      this.layout = this.createDecouplingCapsLayout()
+      this.solved = true
+      this.activeSubSolver = null
+      return
+    }
+
     // Initialize PackSolver2 if not already created
     if (!this.activeSubSolver) {
       const packInput = this.createPackInput()
@@ -62,6 +119,131 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
       this.solved = true
       this.activeSubSolver = null
     }
+  }
+
+  private createDecouplingCapsLayout(): OutputLayout {
+    const entries = Object.entries(this.partitionInputProblem.chipMap).map(
+      ([chipId, chip]) => {
+        const connectedMainPin = this.getStronglyConnectedExternalPin(
+          chipId,
+          chip,
+        )
+        const rotation = getPreferredRotation(chip)
+        const layoutSize = this.getChipLayoutSize(chip)
+        const rotatedSize = getRotatedSize(layoutSize, rotation)
+
+        return {
+          chipId,
+          connectedMainPin,
+          rotation,
+          rotatedSize,
+        }
+      },
+    )
+
+    const externalPinSideCounts = entries.reduce(
+      (counts, entry) => {
+        if (entry.connectedMainPin?.side.startsWith("x")) counts.x += 1
+        if (entry.connectedMainPin?.side.startsWith("y")) counts.y += 1
+        return counts
+      },
+      { x: 0, y: 0 },
+    )
+    const layoutAxis: LayoutAxis =
+      externalPinSideCounts.x > externalPinSideCounts.y ? "y" : "x"
+
+    entries.sort((a, b) => {
+      const aHasMainPin = a.connectedMainPin ? 1 : 0
+      const bHasMainPin = b.connectedMainPin ? 1 : 0
+      if (aHasMainPin !== bHasMainPin) return bHasMainPin - aHasMainPin
+
+      const aCoordinate = this.getDecouplingCapSortCoordinate(a, layoutAxis)
+      const bCoordinate = this.getDecouplingCapSortCoordinate(b, layoutAxis)
+
+      if (aCoordinate !== bCoordinate) return aCoordinate - bCoordinate
+      return compareNaturalChipIds(a.chipId, b.chipId)
+    })
+
+    const gap =
+      this.partitionInputProblem.decouplingCapsGap ??
+      this.partitionInputProblem.chipGap
+    const totalSpan =
+      entries.reduce((sum, entry) => {
+        return sum + entry.rotatedSize[layoutAxis]
+      }, 0) +
+      Math.max(0, entries.length - 1) * gap
+    const chipPlacements: Record<string, Placement> = {}
+    let cursor = -totalSpan / 2
+
+    for (const entry of entries) {
+      const span = entry.rotatedSize[layoutAxis]
+      const center = cursor + span / 2
+
+      chipPlacements[entry.chipId] = {
+        x: layoutAxis === "x" ? center : 0,
+        y: layoutAxis === "y" ? center : 0,
+        ccwRotationDegrees: entry.rotation,
+      }
+
+      cursor += span + gap
+    }
+
+    return {
+      chipPlacements,
+      groupPlacements: {},
+    }
+  }
+
+  private getChipLayoutSize(chip: Chip) {
+    let minX = -chip.size.x / 2
+    let maxX = chip.size.x / 2
+    let minY = -chip.size.y / 2
+    let maxY = chip.size.y / 2
+
+    for (const pinId of chip.pins) {
+      const pin = this.partitionInputProblem.chipPinMap[pinId]
+      if (!pin) continue
+
+      minX = Math.min(minX, pin.offset.x - PIN_SIZE / 2)
+      maxX = Math.max(maxX, pin.offset.x + PIN_SIZE / 2)
+      minY = Math.min(minY, pin.offset.y - PIN_SIZE / 2)
+      maxY = Math.max(maxY, pin.offset.y + PIN_SIZE / 2)
+    }
+
+    return {
+      x: maxX - minX,
+      y: maxY - minY,
+    }
+  }
+
+  private getDecouplingCapSortCoordinate(
+    entry: {
+      connectedMainPin: ChipPin | null
+    },
+    fallbackLayoutAxis: LayoutAxis,
+  ) {
+    const mainPin = entry.connectedMainPin
+    if (!mainPin) return 0
+
+    const sideAwareAxis =
+      getLayoutAxisForExternalSide(mainPin.side) ?? fallbackLayoutAxis
+    return mainPin.offset[sideAwareAxis]
+  }
+
+  private getStronglyConnectedExternalPin(
+    chipId: ChipId,
+    chip: Chip,
+  ): ChipPin | null {
+    for (const pinId of chip.pins) {
+      for (const connectedPin of this.pinIdToStronglyConnectedPins[pinId] ??
+        []) {
+        if (getChipIdFromPinId(connectedPin.pinId) !== chipId) {
+          return connectedPin
+        }
+      }
+    }
+
+    return null
   }
 
   private createPackInput(): PackInput {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bpc-graph": "^0.0.66",
     "calculate-packing": "^0.0.31",
     "circuit-json": "^0.0.226",
+    "circuit-to-svg": "0.0.345",
     "graphics-debug": "^0.0.64",
     "react-cosmos": "^7.0.0",
     "react-cosmos-plugin-vite": "^7.0.0",

--- a/tests/ChipPartitionsSolver.test.ts
+++ b/tests/ChipPartitionsSolver.test.ts
@@ -188,3 +188,85 @@ test("ChipPartitionsSolver visualization contains partition components", () => {
   expect(visualization.rects?.length).toBeGreaterThan(0)
   expect(visualization.texts?.length).toBeGreaterThan(0)
 })
+
+test("ChipPartitionsSolver preserves inherited decoupling nets from main-chip pins", () => {
+  const inputProblem: InputProblem = {
+    chipMap: {
+      U1: {
+        chipId: "U1",
+        pins: ["U1.VCC", "U1.GND", "U1.IO"],
+        size: { x: 4, y: 4 },
+      },
+      C1: {
+        chipId: "C1",
+        pins: ["C1.1", "C1.2"],
+        size: { x: 1, y: 0.5 },
+      },
+      C2: {
+        chipId: "C2",
+        pins: ["C2.1", "C2.2"],
+        size: { x: 1, y: 0.5 },
+      },
+    },
+    chipPinMap: {
+      "U1.VCC": { pinId: "U1.VCC", offset: { x: -1, y: 2 }, side: "y+" },
+      "U1.GND": { pinId: "U1.GND", offset: { x: 1, y: 2 }, side: "y+" },
+      "U1.IO": { pinId: "U1.IO", offset: { x: 0, y: -2 }, side: "y-" },
+      "C1.1": { pinId: "C1.1", offset: { x: -0.25, y: 0 }, side: "x-" },
+      "C1.2": { pinId: "C1.2", offset: { x: 0.25, y: 0 }, side: "x+" },
+      "C2.1": { pinId: "C2.1", offset: { x: -0.25, y: 0 }, side: "x-" },
+      "C2.2": { pinId: "C2.2", offset: { x: 0.25, y: 0 }, side: "x+" },
+    },
+    netMap: {
+      VCC: { netId: "VCC", isPositiveVoltageSource: true },
+      GND: { netId: "GND", isGround: true },
+      SIG: { netId: "SIG" },
+    },
+    pinStrongConnMap: {
+      "C1.1-U1.VCC": true,
+      "U1.VCC-C1.1": true,
+      "C1.2-U1.GND": true,
+      "U1.GND-C1.2": true,
+      "C2.1-U1.VCC": true,
+      "U1.VCC-C2.1": true,
+      "C2.2-U1.GND": true,
+      "U1.GND-C2.2": true,
+    },
+    netConnMap: {
+      "U1.VCC-VCC": true,
+      "U1.GND-GND": true,
+      "U1.IO-SIG": true,
+    },
+    chipGap: 0.2,
+    partitionGap: 2,
+  }
+
+  const solver = new ChipPartitionsSolver({
+    inputProblem,
+    decouplingCapGroups: [
+      {
+        decouplingCapGroupId: "decap_group_U1__VCC__GND",
+        mainChipId: "U1",
+        decouplingCapChipIds: ["C1", "C2"],
+        netPair: ["VCC", "GND"],
+      },
+    ],
+  })
+
+  solver.solve()
+
+  const decapPartition = solver.partitions.find(
+    (partition) => partition.partitionType === "decoupling_caps",
+  )
+
+  expect(decapPartition).toBeDefined()
+  expect(Object.keys(decapPartition!.netMap).sort()).toEqual(["GND", "VCC"])
+  expect(decapPartition!.netConnMap).toMatchObject({
+    "C1.1-VCC": true,
+    "C1.2-GND": true,
+    "C2.1-VCC": true,
+    "C2.2-GND": true,
+  })
+  expect(decapPartition!.netConnMap["C1.1-SIG"]).toBeUndefined()
+  expect(decapPartition!.netConnMap["C2.1-SIG"]).toBeUndefined()
+})

--- a/tests/PackInnerPartitionsSolver/decoupling-cap-main-pin-layout.test.ts
+++ b/tests/PackInnerPartitionsSolver/decoupling-cap-main-pin-layout.test.ts
@@ -149,6 +149,43 @@ test("decoupling cap spacing includes pin envelope beyond the chip body", () => 
   expect(centerDistance).toBeCloseTo(1.55)
 })
 
+test("decoupling cap layout uses positive-voltage main pins for ordering", () => {
+  const partition = makeDecouplingCapPartition()
+  partition.chipMap = {
+    C1: {
+      chipId: "C1",
+      pins: ["C1.2", "C1.1"],
+      size: { x: 1, y: 0.5 },
+      availableRotations: [0],
+    },
+    C2: {
+      chipId: "C2",
+      pins: ["C2.2", "C2.1"],
+      size: { x: 1, y: 0.5 },
+      availableRotations: [0],
+    },
+  }
+
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: partition,
+    pinIdToStronglyConnectedPins: {
+      "C1.2": [makeMainPin("U1.GND1", { x: 2, y: 2 }, "y+")],
+      "C1.1": [makeMainPin("U1.VCC1", { x: -2, y: 2 }, "y+")],
+      "C2.2": [makeMainPin("U1.GND2", { x: -2, y: 2 }, "y+")],
+      "C2.1": [makeMainPin("U1.VCC2", { x: 2, y: 2 }, "y+")],
+    },
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  const placements = solver.layout!.chipPlacements
+
+  expect(placements.C1!.y).toBeCloseTo(0)
+  expect(placements.C2!.y).toBeCloseTo(0)
+  expect(placements.C1!.x).toBeLessThan(placements.C2!.x)
+})
+
 test("caps without external main-pin data fall back to natural chip id order", () => {
   const solver = new SingleInnerPartitionPackingSolver({
     partitionInputProblem: makeDecouplingCapPartition(),

--- a/tests/PackInnerPartitionsSolver/decoupling-cap-main-pin-layout.test.ts
+++ b/tests/PackInnerPartitionsSolver/decoupling-cap-main-pin-layout.test.ts
@@ -1,0 +1,165 @@
+import { expect, test } from "bun:test"
+import { SingleInnerPartitionPackingSolver } from "../../lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver"
+import type {
+  ChipPin,
+  PartitionInputProblem,
+  PinId,
+} from "../../lib/types/InputProblem"
+
+const makeDecouplingCapPartition = (): PartitionInputProblem => ({
+  chipMap: {
+    C10: {
+      chipId: "C10",
+      pins: ["C10.1", "C10.2"],
+      size: { x: 1, y: 0.5 },
+      availableRotations: [0],
+    },
+    C1: {
+      chipId: "C1",
+      pins: ["C1.1", "C1.2"],
+      size: { x: 1, y: 0.5 },
+      availableRotations: [0],
+    },
+    C2: {
+      chipId: "C2",
+      pins: ["C2.1", "C2.2"],
+      size: { x: 1, y: 0.5 },
+      availableRotations: [0],
+    },
+  },
+  chipPinMap: {
+    "C10.1": { pinId: "C10.1", offset: { x: 0, y: 0.25 }, side: "y+" },
+    "C10.2": { pinId: "C10.2", offset: { x: 0, y: -0.25 }, side: "y-" },
+    "C1.1": { pinId: "C1.1", offset: { x: 0, y: 0.25 }, side: "y+" },
+    "C1.2": { pinId: "C1.2", offset: { x: 0, y: -0.25 }, side: "y-" },
+    "C2.1": { pinId: "C2.1", offset: { x: 0, y: 0.25 }, side: "y+" },
+    "C2.2": { pinId: "C2.2", offset: { x: 0, y: -0.25 }, side: "y-" },
+  },
+  netMap: {
+    VCC: { netId: "VCC", isPositiveVoltageSource: true },
+    GND: { netId: "GND", isGround: true },
+  },
+  pinStrongConnMap: {},
+  netConnMap: {
+    "C10.1-VCC": true,
+    "C10.2-GND": true,
+    "C1.1-VCC": true,
+    "C1.2-GND": true,
+    "C2.1-VCC": true,
+    "C2.2-GND": true,
+  },
+  chipGap: 0.6,
+  decouplingCapsGap: 0.25,
+  partitionGap: 1.2,
+  isPartition: true,
+  partitionType: "decoupling_caps",
+})
+
+const makeMainPin = (
+  pinId: PinId,
+  offset: { x: number; y: number },
+  side: ChipPin["side"],
+): ChipPin => ({
+  pinId,
+  offset,
+  side,
+})
+
+test("decoupling caps connected to x-side main pins are stacked by main pin y order", () => {
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: makeDecouplingCapPartition(),
+    pinIdToStronglyConnectedPins: {
+      "C10.1": [makeMainPin("U1.10", { x: 2, y: 2 }, "x+")],
+      "C1.1": [makeMainPin("U1.1", { x: 2, y: -2 }, "x+")],
+      "C2.1": [makeMainPin("U1.2", { x: 2, y: 0 }, "x+")],
+    },
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  const placements = solver.layout!.chipPlacements
+
+  expect(placements.C1!.x).toBeCloseTo(0)
+  expect(placements.C2!.x).toBeCloseTo(0)
+  expect(placements.C10!.x).toBeCloseTo(0)
+  expect(placements.C1!.y).toBeLessThan(placements.C2!.y)
+  expect(placements.C2!.y).toBeLessThan(placements.C10!.y)
+})
+
+test("decoupling caps connected to y-side main pins are laid out by main pin x order", () => {
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: makeDecouplingCapPartition(),
+    pinIdToStronglyConnectedPins: {
+      "C10.1": [makeMainPin("U1.10", { x: 2, y: 2 }, "y+")],
+      "C1.1": [makeMainPin("U1.1", { x: -2, y: 2 }, "y+")],
+      "C2.1": [makeMainPin("U1.2", { x: 0, y: 2 }, "y+")],
+    },
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  const placements = solver.layout!.chipPlacements
+
+  expect(placements.C1!.y).toBeCloseTo(0)
+  expect(placements.C2!.y).toBeCloseTo(0)
+  expect(placements.C10!.y).toBeCloseTo(0)
+  expect(placements.C1!.x).toBeLessThan(placements.C2!.x)
+  expect(placements.C2!.x).toBeLessThan(placements.C10!.x)
+})
+
+test("decoupling cap spacing includes pin envelope beyond the chip body", () => {
+  const partition = makeDecouplingCapPartition()
+  partition.chipMap = {
+    C1: {
+      chipId: "C1",
+      pins: ["C1.1", "C1.2"],
+      size: { x: 0.2, y: 0.2 },
+      availableRotations: [0],
+    },
+    C2: {
+      chipId: "C2",
+      pins: ["C2.1", "C2.2"],
+      size: { x: 0.2, y: 0.2 },
+      availableRotations: [0],
+    },
+  }
+  partition.chipPinMap = {
+    "C1.1": { pinId: "C1.1", offset: { x: -0.6, y: 0 }, side: "x-" },
+    "C1.2": { pinId: "C1.2", offset: { x: 0.6, y: 0 }, side: "x+" },
+    "C2.1": { pinId: "C2.1", offset: { x: -0.6, y: 0 }, side: "x-" },
+    "C2.2": { pinId: "C2.2", offset: { x: 0.6, y: 0 }, side: "x+" },
+  }
+
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: partition,
+    pinIdToStronglyConnectedPins: {
+      "C1.1": [makeMainPin("U1.1", { x: -2, y: 2 }, "y+")],
+      "C2.1": [makeMainPin("U1.2", { x: 2, y: 2 }, "y+")],
+    },
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  const placements = solver.layout!.chipPlacements
+  const centerDistance = Math.abs(placements.C2!.x - placements.C1!.x)
+
+  expect(centerDistance).toBeCloseTo(1.55)
+})
+
+test("caps without external main-pin data fall back to natural chip id order", () => {
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: makeDecouplingCapPartition(),
+    pinIdToStronglyConnectedPins: {},
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  const placements = solver.layout!.chipPlacements
+
+  expect(placements.C1!.x).toBeLessThan(placements.C2!.x)
+  expect(placements.C2!.x).toBeLessThan(placements.C10!.x)
+})


### PR DESCRIPTION
## Summary
- add a deterministic fast path for `decoupling_caps` partitions instead of sending tiny bypass-cap groups through the generic packer
- order caps by their strongly connected main-chip pin coordinate when that context is available, with natural chip-id fallback when it is not
- compute spacing from the chip body plus pin envelope so protruding pads cannot overlap in the generated row
- add focused solver coverage for x-side/y-side main-pin ordering, pin-envelope spacing, and fallback ordering
- pin `circuit-to-svg` to a version that exports the schematic simulation helper required by the existing test suite, making CI runnable again

/claim #15

## Verification
- `npm exec --yes bun -- test tests/PackInnerPartitionsSolver/decoupling-cap-main-pin-layout.test.ts`
- `npm exec --yes bun -- test`
- `npm exec --yes bun -- x tsc --noEmit`
- `npm exec --yes bun -- run build`
- `npm exec --yes bun -- x biome format package.json lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts tests/PackInnerPartitionsSolver/decoupling-cap-main-pin-layout.test.ts`
- `git diff --check`