### PR TITLE
Improve net-aware decoupling cap layout

### DIFF
--- a/lib/solvers/ChipPartitionsSolver/ChipPartitionsSolver.ts
+++ b/lib/solvers/ChipPartitionsSolver/ChipPartitionsSolver.ts
@@ -49,7 +49,10 @@ export class ChipPartitionsSolver extends BaseSolver {
 
     // 1) Build decoupling-cap-only partitions (exclude the main chip for each group)
     const decapChipIdSet = new Set<ChipId>()
-    const decapGroupPartitions: ChipId[][] = []
+    const decapGroupPartitions: Array<{
+      chipIds: ChipId[]
+      netPair: [NetId, NetId]
+    }> = []
 
     if (this.decouplingCapGroups && this.decouplingCapGroups.length > 0) {
       for (const group of this.decouplingCapGroups) {
@@ -61,7 +64,10 @@ export class ChipPartitionsSolver extends BaseSolver {
         }
         // Only add a partition if there are at least two caps present in the inputProblem
         if (capsOnly.length >= 2) {
-          decapGroupPartitions.push(capsOnly)
+          decapGroupPartitions.push({
+            chipIds: capsOnly,
+            netPair: group.netPair,
+          })
           // Mark these caps as handled by decoupling-cap partitions
           for (const capId of capsOnly) {
             decapChipIdSet.add(capId)
@@ -119,8 +125,9 @@ export class ChipPartitionsSolver extends BaseSolver {
 
     return [
       ...decapGroupPartitions.map((partition) =>
-        this.createInputProblemFromPartition(partition, inputProblem, {
+        this.createInputProblemFromPartition(partition.chipIds, inputProblem, {
           partitionType: "decoupling_caps",
+          decouplingCapNetPair: partition.netPair,
         }),
       ),
       ...nonDecapPartitions.map((partition) =>
@@ -188,6 +195,7 @@ export class ChipPartitionsSolver extends BaseSolver {
     originalProblem: InputProblem,
     opts?: {
       partitionType?: "default" | "decoupling_caps"
+      decouplingCapNetPair?: [NetId, NetId]
     },
   ): PartitionInputProblem {
     const chipIds = partition
@@ -242,6 +250,19 @@ export class ChipPartitionsSolver extends BaseSolver {
       }
     }
 
+    if (
+      opts?.partitionType === "decoupling_caps" &&
+      opts.decouplingCapNetPair
+    ) {
+      this.addExternalDecouplingNetConnections({
+        originalProblem,
+        relevantPinIds,
+        allowedNetIds: new Set(opts.decouplingCapNetPair),
+        relevantNetIds,
+        netConnMap,
+      })
+    }
+
     for (const netId of relevantNetIds) {
       if (originalProblem.netMap[netId]) {
         netMap[netId] = originalProblem.netMap[netId]
@@ -257,6 +278,52 @@ export class ChipPartitionsSolver extends BaseSolver {
       netConnMap,
       isPartition: true,
       partitionType: opts?.partitionType,
+    }
+  }
+
+  private addExternalDecouplingNetConnections({
+    originalProblem,
+    relevantPinIds,
+    allowedNetIds,
+    relevantNetIds,
+    netConnMap,
+  }: {
+    originalProblem: InputProblem
+    relevantPinIds: Set<PinId>
+    allowedNetIds: Set<NetId>
+    relevantNetIds: Set<NetId>
+    netConnMap: Record<string, boolean>
+  }) {
+    const copyAllowedNets = (targetPinId: PinId, externalPinId: PinId) => {
+      for (const [connKey, isConnected] of Object.entries(
+        originalProblem.netConnMap,
+      )) {
+        if (!isConnected) continue
+
+        const [pinId, netId] = connKey.split("-") as [PinId, NetId]
+        if (pinId !== externalPinId || !allowedNetIds.has(netId)) continue
+
+        relevantNetIds.add(netId)
+        netConnMap[`${targetPinId}-${netId}`] = true
+      }
+    }
+
+    for (const [connKey, isConnected] of Object.entries(
+      originalProblem.pinStrongConnMap,
+    )) {
+      if (!isConnected) continue
+
+      const [pinAId, pinBId] = connKey.split("-") as [PinId, PinId]
+      const pinAIsRelevant = relevantPinIds.has(pinAId)
+      const pinBIsRelevant = relevantPinIds.has(pinBId)
+
+      if (pinAIsRelevant === pinBIsRelevant) continue
+
+      if (pinAIsRelevant) {
+        copyAllowedNets(pinAId, pinBId)
+      } else {
+        copyAllowedNets(pinBId, pinAId)
+      }
     }
   }
 

--- a/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
@@ -12,6 +12,7 @@ import type {
   PinId,
   ChipId,
   NetId,
+  Chip,
   ChipPin,
   PartitionInputProblem,
 } from "../../types/InputProblem"
@@ -21,6 +22,56 @@ import { getPadsBoundingBox } from "./getPadsBoundingBox"
 import { doBasicInputProblemLayout } from "../LayoutPipelineSolver/doBasicInputProblemLayout"
 
 const PIN_SIZE = 0.1
+
+type LayoutAxis = "x" | "y"
+
+const compareNaturalChipIds = (a: ChipId, b: ChipId) => {
+  const aParts = a.match(/\d+|\D+/g) ?? [a]
+  const bParts = b.match(/\d+|\D+/g) ?? [b]
+  const partCount = Math.min(aParts.length, bParts.length)
+
+  for (let i = 0; i < partCount; i++) {
+    const aPart = aParts[i]!
+    const bPart = bParts[i]!
+    const aNumber = Number(aPart)
+    const bNumber = Number(bPart)
+    const aIsNumber = Number.isInteger(aNumber)
+    const bIsNumber = Number.isInteger(bNumber)
+
+    if (aIsNumber && bIsNumber && aNumber !== bNumber) {
+      return aNumber - bNumber
+    }
+
+    if (aPart !== bPart) {
+      return aPart.localeCompare(bPart)
+    }
+  }
+
+  return aParts.length - bParts.length
+}
+
+const getChipIdFromPinId = (pinId: PinId): ChipId =>
+  pinId.split(".")[0] ?? pinId
+
+const getPreferredRotation = (chip: Chip): 0 | 90 | 180 | 270 => {
+  if (!chip.availableRotations?.length) return 0
+  return chip.availableRotations.includes(0) ? 0 : chip.availableRotations[0]!
+}
+
+const getRotatedSize = (size: { x: number; y: number }, rotation: number) => {
+  if (rotation === 90 || rotation === 270) {
+    return { x: size.y, y: size.x }
+  }
+  return size
+}
+
+const getLayoutAxisForExternalSide = (
+  side: ChipPin["side"] | undefined,
+): LayoutAxis | null => {
+  if (side?.startsWith("x")) return "y"
+  if (side?.startsWith("y")) return "x"
+  return null
+}
 
 export class SingleInnerPartitionPackingSolver extends BaseSolver {
   partitionInputProblem: PartitionInputProblem
@@ -38,6 +89,13 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
   }
 
   override _step() {
+    if (this.partitionInputProblem.partitionType === "decoupling_caps") {
+      this.layout = this.createDecouplingCapsLayout()
+      this.solved = true
+      this.activeSubSolver = null
+      return
+    }
+
     // Initialize PackSolver2 if not already created
     if (!this.activeSubSolver) {
       const packInput = this.createPackInput()
@@ -62,6 +120,173 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
       this.solved = true
       this.activeSubSolver = null
     }
+  }
+
+  private createDecouplingCapsLayout(): OutputLayout {
+    const entries = Object.entries(this.partitionInputProblem.chipMap).map(
+      ([chipId, chip]) => {
+        const connectedMainPin = this.getPreferredExternalMainPin(chipId, chip)
+        const rotation = getPreferredRotation(chip)
+        const layoutSize = this.getChipLayoutSize(chip)
+        const rotatedSize = getRotatedSize(layoutSize, rotation)
+
+        return {
+          chipId,
+          connectedMainPin,
+          rotation,
+          rotatedSize,
+        }
+      },
+    )
+
+    const externalPinSideCounts = entries.reduce(
+      (counts, entry) => {
+        if (entry.connectedMainPin?.side.startsWith("x")) counts.x += 1
+        if (entry.connectedMainPin?.side.startsWith("y")) counts.y += 1
+        return counts
+      },
+      { x: 0, y: 0 },
+    )
+    const layoutAxis: LayoutAxis =
+      externalPinSideCounts.x > externalPinSideCounts.y ? "y" : "x"
+
+    entries.sort((a, b) => {
+      const aHasMainPin = a.connectedMainPin ? 1 : 0
+      const bHasMainPin = b.connectedMainPin ? 1 : 0
+      if (aHasMainPin !== bHasMainPin) return bHasMainPin - aHasMainPin
+
+      const aCoordinate = this.getDecouplingCapSortCoordinate(a, layoutAxis)
+      const bCoordinate = this.getDecouplingCapSortCoordinate(b, layoutAxis)
+
+      if (aCoordinate !== bCoordinate) return aCoordinate - bCoordinate
+      return compareNaturalChipIds(a.chipId, b.chipId)
+    })
+
+    const gap =
+      this.partitionInputProblem.decouplingCapsGap ??
+      this.partitionInputProblem.chipGap
+    const totalSpan =
+      entries.reduce((sum, entry) => {
+        return sum + entry.rotatedSize[layoutAxis]
+      }, 0) +
+      Math.max(0, entries.length - 1) * gap
+    const chipPlacements: Record<string, Placement> = {}
+    let cursor = -totalSpan / 2
+
+    for (const entry of entries) {
+      const span = entry.rotatedSize[layoutAxis]
+      const center = cursor + span / 2
+
+      chipPlacements[entry.chipId] = {
+        x: layoutAxis === "x" ? center : 0,
+        y: layoutAxis === "y" ? center : 0,
+        ccwRotationDegrees: entry.rotation,
+      }
+
+      cursor += span + gap
+    }
+
+    return {
+      chipPlacements,
+      groupPlacements: {},
+    }
+  }
+
+  private getChipLayoutSize(chip: Chip) {
+    let minX = -chip.size.x / 2
+    let maxX = chip.size.x / 2
+    let minY = -chip.size.y / 2
+    let maxY = chip.size.y / 2
+
+    for (const pinId of chip.pins) {
+      const pin = this.partitionInputProblem.chipPinMap[pinId]
+      if (!pin) continue
+
+      minX = Math.min(minX, pin.offset.x - PIN_SIZE / 2)
+      maxX = Math.max(maxX, pin.offset.x + PIN_SIZE / 2)
+      minY = Math.min(minY, pin.offset.y - PIN_SIZE / 2)
+      maxY = Math.max(maxY, pin.offset.y + PIN_SIZE / 2)
+    }
+
+    return {
+      x: maxX - minX,
+      y: maxY - minY,
+    }
+  }
+
+  private getDecouplingCapSortCoordinate(
+    entry: {
+      connectedMainPin: ChipPin | null
+    },
+    fallbackLayoutAxis: LayoutAxis,
+  ) {
+    const mainPin = entry.connectedMainPin
+    if (!mainPin) return 0
+
+    const sideAwareAxis =
+      getLayoutAxisForExternalSide(mainPin.side) ?? fallbackLayoutAxis
+    return mainPin.offset[sideAwareAxis]
+  }
+
+  private getPreferredExternalMainPin(
+    chipId: ChipId,
+    chip: Chip,
+  ): ChipPin | null {
+    const candidates: Array<{
+      capPinId: PinId
+      externalPin: ChipPin
+      isPositiveVoltage: boolean
+      isGround: boolean
+    }> = []
+
+    for (const pinId of chip.pins) {
+      for (const connectedPin of this.pinIdToStronglyConnectedPins[pinId] ??
+        []) {
+        if (getChipIdFromPinId(connectedPin.pinId) === chipId) continue
+        const netRole = this.getPinNetRole(pinId)
+
+        candidates.push({
+          capPinId: pinId,
+          externalPin: connectedPin,
+          isPositiveVoltage: netRole.isPositiveVoltage,
+          isGround: netRole.isGround,
+        })
+      }
+    }
+
+    candidates.sort((a, b) => {
+      if (a.isPositiveVoltage !== b.isPositiveVoltage) {
+        return a.isPositiveVoltage ? -1 : 1
+      }
+      if (a.isGround !== b.isGround) return a.isGround ? -1 : 1
+      const pinCompare = a.capPinId.localeCompare(b.capPinId)
+      if (pinCompare !== 0) return pinCompare
+      return a.externalPin.pinId.localeCompare(b.externalPin.pinId)
+    })
+
+    return candidates[0]?.externalPin ?? null
+  }
+
+  private getPinNetRole(pinId: PinId) {
+    const role = {
+      isPositiveVoltage: false,
+      isGround: false,
+    }
+
+    for (const [connKey, isConnected] of Object.entries(
+      this.partitionInputProblem.netConnMap,
+    )) {
+      if (!isConnected) continue
+
+      const [connectedPinId, netId] = connKey.split("-") as [PinId, NetId]
+      if (connectedPinId !== pinId) continue
+
+      const net = this.partitionInputProblem.netMap[netId]
+      role.isPositiveVoltage ||= Boolean(net?.isPositiveVoltageSource)
+      role.isGround ||= Boolean(net?.isGround)
+    }
+
+    return role
   }
 
   private createPackInput(): PackInput {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bpc-graph": "^0.0.66",
     "calculate-packing": "^0.0.31",
     "circuit-json": "^0.0.226",
+    "circuit-to-svg": "0.0.345",
     "graphics-debug": "^0.0.64",
     "react-cosmos": "^7.0.0",
     "react-cosmos-plugin-vite": "^7.0.0",

--- a/tests/ChipPartitionsSolver.test.ts
+++ b/tests/ChipPartitionsSolver.test.ts
@@ -188,3 +188,105 @@ test("ChipPartitionsSolver visualization contains partition components", () => {
   expect(visualization.rects?.length).toBeGreaterThan(0)
   expect(visualization.texts?.length).toBeGreaterThan(0)
 })
+
+test("ChipPartitionsSolver preserves inherited decoupling nets from main-chip pins", () => {
+  const inputProblem: InputProblem = {
+    chipMap: {
+      U1: {
+        chipId: "U1",
+        pins: ["U1.VCC", "U1.GND"],
+        size: { x: 2, y: 2 },
+      },
+      C1: {
+        chipId: "C1",
+        pins: ["C1.VCC", "C1.GND"],
+        size: { x: 0.8, y: 0.4 },
+      },
+      C2: {
+        chipId: "C2",
+        pins: ["C2.VCC", "C2.GND"],
+        size: { x: 0.8, y: 0.4 },
+      },
+    },
+    chipPinMap: {
+      "U1.VCC": {
+        pinId: "U1.VCC",
+        offset: { x: 1, y: 0.5 },
+        side: "x+",
+      },
+      "U1.GND": {
+        pinId: "U1.GND",
+        offset: { x: -1, y: -0.5 },
+        side: "x-",
+      },
+      "C1.VCC": {
+        pinId: "C1.VCC",
+        offset: { x: 0, y: 0.2 },
+        side: "y+",
+      },
+      "C1.GND": {
+        pinId: "C1.GND",
+        offset: { x: 0, y: -0.2 },
+        side: "y-",
+      },
+      "C2.VCC": {
+        pinId: "C2.VCC",
+        offset: { x: 0, y: 0.2 },
+        side: "y+",
+      },
+      "C2.GND": {
+        pinId: "C2.GND",
+        offset: { x: 0, y: -0.2 },
+        side: "y-",
+      },
+    },
+    netMap: {
+      VCC: { netId: "VCC", isPositiveVoltageSource: true },
+      GND: { netId: "GND", isGround: true },
+      SIG: { netId: "SIG" },
+    },
+    pinStrongConnMap: {
+      "C1.VCC-U1.VCC": true,
+      "U1.VCC-C1.VCC": true,
+      "C1.GND-U1.GND": true,
+      "U1.GND-C1.GND": true,
+      "C2.VCC-U1.VCC": true,
+      "U1.VCC-C2.VCC": true,
+      "C2.GND-U1.GND": true,
+      "U1.GND-C2.GND": true,
+    },
+    netConnMap: {
+      "U1.VCC-VCC": true,
+      "U1.GND-GND": true,
+      "U1.VCC-SIG": true,
+    },
+    chipGap: 0.2,
+    partitionGap: 2,
+  }
+
+  const solver = new ChipPartitionsSolver({
+    inputProblem,
+    decouplingCapGroups: [
+      {
+        decouplingCapGroupId: "decap_U1_GND_VCC",
+        mainChipId: "U1",
+        netPair: ["GND", "VCC"],
+        decouplingCapChipIds: ["C1", "C2"],
+      },
+    ],
+  })
+  solver.solve()
+
+  const decapPartition = solver.partitions.find(
+    (partition) => partition.partitionType === "decoupling_caps",
+  )
+
+  expect(decapPartition).toBeDefined()
+  expect(Object.keys(decapPartition!.chipMap).sort()).toEqual(["C1", "C2"])
+  expect(Object.keys(decapPartition!.netMap).sort()).toEqual(["GND", "VCC"])
+  expect(decapPartition!.netConnMap["C1.VCC-VCC"]).toBe(true)
+  expect(decapPartition!.netConnMap["C1.GND-GND"]).toBe(true)
+  expect(decapPartition!.netConnMap["C2.VCC-VCC"]).toBe(true)
+  expect(decapPartition!.netConnMap["C2.GND-GND"]).toBe(true)
+  expect(decapPartition!.netConnMap["C1.VCC-SIG"]).toBeUndefined()
+})

--- a/tests/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.test.ts
+++ b/tests/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.test.ts
@@ -1,0 +1,175 @@
+import { expect, test } from "bun:test"
+import { SingleInnerPartitionPackingSolver } from "../../lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver"
+import type {
+  ChipPin,
+  PartitionInputProblem,
+  PinId,
+} from "../../lib/types/InputProblem"
+
+const makeMainPin = (
+  pinId: PinId,
+  offset: { x: number; y: number },
+  side: ChipPin["side"],
+): ChipPin => ({
+  pinId,
+  offset,
+  side,
+})
+
+const makeDecouplingCapPartition = (): PartitionInputProblem => ({
+  chipMap: {
+    C10: {
+      chipId: "C10",
+      pins: ["C10.VCC", "C10.GND"],
+      size: { x: 1, y: 0.5 },
+      availableRotations: [0],
+    },
+    C1: {
+      chipId: "C1",
+      pins: ["C1.VCC", "C1.GND"],
+      size: { x: 1, y: 0.5 },
+      availableRotations: [0],
+    },
+    C2: {
+      chipId: "C2",
+      pins: ["C2.VCC", "C2.GND"],
+      size: { x: 1, y: 0.5 },
+      availableRotations: [0],
+    },
+  },
+  chipPinMap: {
+    "C10.VCC": { pinId: "C10.VCC", offset: { x: 0, y: 0.25 }, side: "y+" },
+    "C10.GND": {
+      pinId: "C10.GND",
+      offset: { x: 0, y: -0.25 },
+      side: "y-",
+    },
+    "C1.VCC": { pinId: "C1.VCC", offset: { x: 0, y: 0.25 }, side: "y+" },
+    "C1.GND": { pinId: "C1.GND", offset: { x: 0, y: -0.25 }, side: "y-" },
+    "C2.VCC": { pinId: "C2.VCC", offset: { x: 0, y: 0.25 }, side: "y+" },
+    "C2.GND": { pinId: "C2.GND", offset: { x: 0, y: -0.25 }, side: "y-" },
+  },
+  netMap: {
+    VCC: { netId: "VCC", isPositiveVoltageSource: true },
+    GND: { netId: "GND", isGround: true },
+  },
+  pinStrongConnMap: {},
+  netConnMap: {
+    "C10.VCC-VCC": true,
+    "C10.GND-GND": true,
+    "C1.VCC-VCC": true,
+    "C1.GND-GND": true,
+    "C2.VCC-VCC": true,
+    "C2.GND-GND": true,
+  },
+  chipGap: 0.6,
+  decouplingCapsGap: 0.25,
+  partitionGap: 1.2,
+  isPartition: true,
+  partitionType: "decoupling_caps",
+})
+
+test("decoupling cap layout uses positive-voltage main pins for ordering", () => {
+  const partition = makeDecouplingCapPartition()
+  partition.chipMap = {
+    C1: {
+      chipId: "C1",
+      pins: ["C1.GND", "C1.VCC"],
+      size: { x: 1, y: 0.5 },
+      availableRotations: [0],
+    },
+    C2: {
+      chipId: "C2",
+      pins: ["C2.GND", "C2.VCC"],
+      size: { x: 1, y: 0.5 },
+      availableRotations: [0],
+    },
+  }
+
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: partition,
+    pinIdToStronglyConnectedPins: {
+      "C1.GND": [makeMainPin("U1.GND1", { x: 2, y: 2 }, "y+")],
+      "C1.VCC": [makeMainPin("U1.VCC1", { x: -2, y: 2 }, "y+")],
+      "C2.GND": [makeMainPin("U1.GND2", { x: -2, y: 2 }, "y+")],
+      "C2.VCC": [makeMainPin("U1.VCC2", { x: 2, y: 2 }, "y+")],
+    },
+  })
+
+  solver.solve()
+
+  const placements = solver.layout!.chipPlacements
+  expect(placements.C1!.x).toBeLessThan(placements.C2!.x)
+  expect(placements.C1!.y).toBeCloseTo(0)
+  expect(placements.C2!.y).toBeCloseTo(0)
+})
+
+test("decoupling caps connected to x-side main pins are stacked by main pin y order", () => {
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: makeDecouplingCapPartition(),
+    pinIdToStronglyConnectedPins: {
+      "C10.VCC": [makeMainPin("U1.VCC10", { x: 2, y: 2 }, "x+")],
+      "C1.VCC": [makeMainPin("U1.VCC1", { x: 2, y: -2 }, "x+")],
+      "C2.VCC": [makeMainPin("U1.VCC2", { x: 2, y: 0 }, "x+")],
+    },
+  })
+
+  solver.solve()
+
+  const placements = solver.layout!.chipPlacements
+  expect(placements.C1!.x).toBeCloseTo(0)
+  expect(placements.C2!.x).toBeCloseTo(0)
+  expect(placements.C10!.x).toBeCloseTo(0)
+  expect(placements.C1!.y).toBeLessThan(placements.C2!.y)
+  expect(placements.C2!.y).toBeLessThan(placements.C10!.y)
+})
+
+test("decoupling cap spacing includes the pin envelope beyond the chip body", () => {
+  const partition = makeDecouplingCapPartition()
+  partition.chipMap = {
+    C1: {
+      chipId: "C1",
+      pins: ["C1.VCC", "C1.GND"],
+      size: { x: 0.2, y: 0.2 },
+      availableRotations: [0],
+    },
+    C2: {
+      chipId: "C2",
+      pins: ["C2.VCC", "C2.GND"],
+      size: { x: 0.2, y: 0.2 },
+      availableRotations: [0],
+    },
+  }
+  partition.chipPinMap = {
+    "C1.VCC": { pinId: "C1.VCC", offset: { x: -0.6, y: 0 }, side: "x-" },
+    "C1.GND": { pinId: "C1.GND", offset: { x: 0.6, y: 0 }, side: "x+" },
+    "C2.VCC": { pinId: "C2.VCC", offset: { x: -0.6, y: 0 }, side: "x-" },
+    "C2.GND": { pinId: "C2.GND", offset: { x: 0.6, y: 0 }, side: "x+" },
+  }
+
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: partition,
+    pinIdToStronglyConnectedPins: {
+      "C1.VCC": [makeMainPin("U1.VCC1", { x: -2, y: 2 }, "y+")],
+      "C2.VCC": [makeMainPin("U1.VCC2", { x: 2, y: 2 }, "y+")],
+    },
+  })
+
+  solver.solve()
+
+  const placements = solver.layout!.chipPlacements
+  expect(Math.abs(placements.C2!.x - placements.C1!.x)).toBeCloseTo(1.55)
+})
+
+test("decoupling caps without external main-pin data fall back to natural order", () => {
+  const solver = new SingleInnerPartitionPackingSolver({
+    partitionInputProblem: makeDecouplingCapPartition(),
+    pinIdToStronglyConnectedPins: {},
+  })
+
+  solver.solve()
+
+  const placements = solver.layout!.chipPlacements
+  expect(placements.C1!.x).toBeLessThan(placements.C2!.x)
+  expect(placements.C2!.x).toBeLessThan(placements.C10!.x)
+})


### PR DESCRIPTION
## Summary
- preserve allowed VCC/GND net membership when decoupling-cap-only partitions inherit those nets through strong connections to the main chip
- add a deterministic fast path for `partitionType === "decoupling_caps"` that orders caps by main-pin coordinates and spaces by the full body + pin envelope
- prefer the positive-voltage-connected external main pin for ordering when both cap pins are strongly connected, with deterministic natural-id fallback behavior
- pin `circuit-to-svg@0.0.345` so the existing full Bun test suite can load the schematic simulation SVG export

/claim #15

## Verification
- `npx --yes bun test tests/ChipPartitionsSolver.test.ts tests/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.test.ts`
- `npx --yes bun test`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun run format:check`
- `npx --yes bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the patch and verification locally.