### PR TITLE
fix: declare runtime dependencies (math-utils, calculate-packing, graphics-debug)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "format:check": "biome format .",
     "build:site": "cosmos-export"
   },
+  "dependencies": {
+    "calculate-packing": "^0.0.75",
+    "graphics-debug": "^0.0.95"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
     "@react-hook/resize-observer": "^2.0.2",
@@ -23,9 +27,7 @@
     "@types/bun": "^1.3.14",
     "bun-match-svg": "^0.0.15",
     "bpc-graph": "^0.0.66",
-    "calculate-packing": "^0.0.75",
     "circuit-json": "^0.0.432",
-    "graphics-debug": "^0.0.95",
     "react-cosmos": "^7.3.0",
     "react-cosmos-plugin-vite": "^7.3.0",
     "tscircuit": "^0.0.1891",
@@ -33,6 +35,7 @@
     "circuit-to-svg": "^0.0.351"
   },
   "peerDependencies": {
+    "@tscircuit/math-utils": "*",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Problem

Clean install can't import the package — `bun add @tscircuit/matchpack` then import throws `Cannot find module`.

Build is `tsup-node` (no bundling), but three packages the shipped `dist` imports were declared only in `devDependencies`. Real runtime imports in `lib/`: `graphics-debug` ×12, `@tscircuit/math-utils` ×5, `calculate-packing` ×4.

## Fix

Per the tscircuit `dependency-check` convention (`internal_lib`): external → `dependencies`, internal `@tscircuit/*` → `peerDependencies` (`"*"`).

- `calculate-packing`, `graphics-debug` → `dependencies`
- `@tscircuit/math-utils` → `peerDependencies` (`"*"`), kept pinned in `devDependencies`

`bunx @tscircuit/dependency-check` passes; format / test / type-check green.

## Verification

Built and packed; clean install resolves this package's deps. (`calculate-packing@0.0.75` has the same defect — fixed in tscircuit/calculate-packing#101 — and the tree bottoms out at `circuit-json`, tscircuit/circuit-json#633.) Same class as tscircuit/dsn-converter#514.
