### PR TITLE
Fix decoupling caps wired only to nets being grouped to the wrong chip

### DIFF
--- a/lib/solvers/IdentifyDecouplingCapsSolver/IdentifyDecouplingCapsSolver.ts
+++ b/lib/solvers/IdentifyDecouplingCapsSolver/IdentifyDecouplingCapsSolver.ts
@@ -4,8 +4,9 @@
  *    a cap's geometry, so the component type is what qualifies it, not the pin count
  * 2. It has exactly 2 pins and restricted rotation (0/180 only or no rotation)
  * 3. One pin indirectly connected to a ground net, one to a positive voltage source
- * 4. It decouples a main chip, reached either by a direct pin-to-pin connection or by
- *    the positive rail it shares with that chip's power pins
+ * 4. It decouples a main chip: one it is directly (pin-to-pin) wired to, or — for a
+ *    cap wired only to the rail — the chip whose directly-wired caps already decouple
+ *    that same rail (see findRailSharingMainChipId)
  */
 
 import type { GraphicsObject } from "graphics-debug"
@@ -35,9 +36,9 @@ export interface DecouplingCapGroup {
  *    the component type is what gates this, not the pin count.
  * 2. It has exactly 2 pins with restricted rotation (0/180 only or no rotation)
  * 3. One pin indirectly connected to a net with isGround and one to isPositiveVoltageSource
- * 4. It decouples a main chip (typically a microcontroller) — one reached by a direct
- *    pin-to-pin connection, or failing that the chip whose power pins share the cap's
- *    positive rail. See findMainChipIdForCap.
+ * 4. It decouples a main chip (typically a microcontroller) — one it is directly
+ *    (pin-to-pin) wired to, or — for a cap wired only to the rail — the chip whose
+ *    directly-wired caps already decouple that rail. See findRailSharingMainChipId.
  */
 export class IdentifyDecouplingCapsSolver extends BaseSolver {
   inputProblem: InputProblem
@@ -100,14 +101,12 @@ export class IdentifyDecouplingCapsSolver extends BaseSolver {
   }
 
   /**
-   * Find the chip a decoupling capacitor belongs to.
+   * Find the chip a decoupling capacitor decouples.
    *
-   * What makes a cap belong to a chip is that it bridges that chip's power rail
-   * and ground. A direct pin-to-pin connection is only one way the netlist can say
-   * so — `U3.DVDD1: ["C18.1", "net.V1_1"]` names the pin, while a bulk cap on the
-   * same rail (`C9.pin1: "net.V1_1"`) names only the net. Both decouple U3, so the
-   * rail is consulted when there is no pin-to-pin edge to follow. Otherwise a cap's
-   * grouping would depend on how its connection happened to be written.
+   * A cap directly wired (pin-to-pin) to a chip decouples that chip. A cap wired
+   * only to the rail's nets — e.g. a bulk cap `C9.pin1: "net.V1_1"` — has no such
+   * edge, so it decouples whichever chip the rail's *directly-wired* caps already
+   * decouple. See findRailSharingMainChipId.
    */
   private findMainChipIdForCap(
     capChip: Chip,
@@ -152,54 +151,36 @@ export class IdentifyDecouplingCapsSolver extends BaseSolver {
     return mainChipId
   }
 
-  /** How many of a chip's pins sit on a net */
-  private countChipPinsOnNet(chip: Chip, netId: NetId): number {
-    let pinsOnNet = 0
-    for (const pinId of chip.pins) {
-      if (this.getNetIdsForPin(pinId).has(netId)) pinsOnNet++
-    }
-    return pinsOnNet
-  }
-
   /**
-   * The chip whose power pins sit on the cap's positive rail.
+   * The chip a rail-only cap (no pin-to-pin edge) decouples: the same chip that a
+   * directly-wired sibling cap on the same rail decouples.
    *
-   * Ground is not consulted because nearly every chip touches it. 2-pin parts on the
-   * rail are skipped too: the thing being decoupled is a multi-pin chip, not another
-   * cap (or diode) sharing the rail. If two chips share a rail (say two MCUs on V3_3),
-   * the one drawing the most power pins from it is the one being decoupled.
+   * C9 is wired only to V1_1/GND, but C18/C7 sit on that same rail and are wired
+   * straight to U3.DVDD, so C9 decouples U3 too. Without such a sibling — a lone cap
+   * on, say, a pin header's power rail — no chip is being decoupled there, so the cap
+   * is left ungrouped rather than attached to whatever multi-pin part touches the net.
    */
   private findRailSharingMainChipId(
     capChip: Chip,
     netPair: [NetId, NetId],
   ): ChipId | null {
-    const powerNetId = netPair.find(
-      (netId) => this.inputProblem.netMap[netId]?.isPositiveVoltageSource,
-    )
-    if (!powerNetId) return null
+    for (const sibling of Object.values(this.inputProblem.chipMap)) {
+      if (sibling.chipId === capChip.chipId) continue
+      if (!sibling.isCapacitor) continue
 
-    // Choose the chip with the most power pins (tie-breaker: lexicographic)
-    let mainChipId: ChipId | null = null
-    let mainChipPowerPinCount = 0
-    for (const [chipId, chip] of Object.entries(this.inputProblem.chipMap)) {
-      if (chipId === capChip.chipId) continue
-      if (chip.pins.length <= 2) continue
-
-      const powerPinCount = this.countChipPinsOnNet(chip, powerNetId)
-      if (powerPinCount === 0) continue
-      if (powerPinCount < mainChipPowerPinCount) continue
+      const siblingPair = this.getNormalizedNetPair(sibling)
       if (
-        mainChipId !== null &&
-        powerPinCount === mainChipPowerPinCount &&
-        chipId > mainChipId
+        !siblingPair ||
+        siblingPair[0] !== netPair[0] ||
+        siblingPair[1] !== netPair[1]
       ) {
         continue
       }
 
-      mainChipId = chipId
-      mainChipPowerPinCount = powerPinCount
+      const mainChipId = this.findStronglyConnectedMainChipId(sibling)
+      if (mainChipId) return mainChipId
     }
-    return mainChipId
+    return null
   }
 
   /** Get all net IDs connected to a pin */
@@ -287,7 +268,8 @@ export class IdentifyDecouplingCapsSolver extends BaseSolver {
     if (!isDecouplingNetPair) return
 
     // Require a chip for the cap to decouple, found by pin-to-pin connection or,
-    // for a cap wired only to the rail, by the rail itself
+    // for a cap wired only to the rail, the chip whose directly-wired caps already
+    // decouple that rail
     const mainChipId = this.findMainChipIdForCap(currentChip, netPair)
     if (!mainChipId) return
 

--- a/tests/IdentifyDecouplingCapsSolver/IdentifyDecouplingCapsSolver07.test.ts
+++ b/tests/IdentifyDecouplingCapsSolver/IdentifyDecouplingCapsSolver07.test.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "bun:test"
+import { IdentifyDecouplingCapsSolver } from "../../lib/solvers/IdentifyDecouplingCapsSolver/IdentifyDecouplingCapsSolver"
+import type { InputProblem } from "../../lib/types/InputProblem"
+
+/**
+ * A decoupling cap is identified by component type, not geometry. CAP1 and DIODE1
+ * are geometrically identical -- both 2-pin, pins on opposite y sides, both bridging
+ * the same VCC/GND rail, both strongly connected to U1. Only CAP1 is a capacitor.
+ * DIODE1 (think TVS diode or voltmeter) must not be grouped.
+ */
+const buildProblem = (): InputProblem => {
+  const twoPinPart = (chipId: string, isCapacitor: boolean) => ({
+    chip: {
+      chipId,
+      pins: [`${chipId}.1`, `${chipId}.2`],
+      size: { x: 0.5, y: 1 },
+      isCapacitor,
+      availableRotations: [0, 180] as Array<0 | 180>,
+    },
+    pins: {
+      [`${chipId}.1`]: {
+        pinId: `${chipId}.1`,
+        offset: { x: 0, y: 0.3 },
+        side: "y+" as const,
+      },
+      [`${chipId}.2`]: {
+        pinId: `${chipId}.2`,
+        offset: { x: 0, y: -0.3 },
+        side: "y-" as const,
+      },
+    },
+  })
+
+  const cap1 = twoPinPart("CAP1", true)
+  const cap2 = twoPinPart("CAP2", true)
+  const diode1 = twoPinPart("DIODE1", false)
+
+  return {
+    chipMap: {
+      U1: {
+        chipId: "U1",
+        pins: ["U1.1", "U1.2", "U1.3"],
+        size: { x: 2, y: 2 },
+        availableRotations: [0],
+      },
+      CAP1: cap1.chip,
+      CAP2: cap2.chip,
+      DIODE1: diode1.chip,
+    },
+    chipPinMap: {
+      "U1.1": { pinId: "U1.1", offset: { x: -1, y: 0.5 }, side: "x-" },
+      "U1.2": { pinId: "U1.2", offset: { x: -1, y: 0 }, side: "x-" },
+      "U1.3": { pinId: "U1.3", offset: { x: -1, y: -0.5 }, side: "x-" },
+      ...cap1.pins,
+      ...cap2.pins,
+      ...diode1.pins,
+    },
+    netMap: {
+      VCC: { netId: "VCC", isPositiveVoltageSource: true },
+      GND: { netId: "GND", isGround: true },
+    },
+    // Each part's top pin is directly connected to a U1 pin (so U1 is the main chip).
+    pinStrongConnMap: {
+      "CAP1.1-U1.1": true,
+      "U1.1-CAP1.1": true,
+      "CAP2.1-U1.2": true,
+      "U1.2-CAP2.1": true,
+      "DIODE1.1-U1.3": true,
+      "U1.3-DIODE1.1": true,
+    },
+    netConnMap: {
+      "CAP1.1-VCC": true,
+      "CAP1.2-GND": true,
+      "CAP2.1-VCC": true,
+      "CAP2.2-GND": true,
+      "DIODE1.1-VCC": true,
+      "DIODE1.2-GND": true,
+    },
+    chipGap: 0.2,
+    partitionGap: 2,
+  }
+}
+
+test("IdentifyDecouplingCapsSolver groups only capacitors, not other 2-pin parts", () => {
+  const solver = new IdentifyDecouplingCapsSolver(buildProblem())
+  solver.solve()
+
+  const grouped = solver.outputDecouplingCapGroups.flatMap(
+    (group) => group.decouplingCapChipIds,
+  )
+
+  expect(new Set(grouped)).toEqual(new Set(["CAP1", "CAP2"]))
+  expect(grouped).not.toContain("DIODE1")
+})


### PR DESCRIPTION
Follow-up to #155. That PR added a rail-sharing fallback so a bulk cap wired only to a power rail (no pin-to-pin edge) could still join the chip it decouples — e.g. the RP2040's C9, wired to `net.V1_1` only, joining U3's V1_1 group. The fallback worked
for that case but was too broad, and regressed other schematics.

## The bug

`findRailSharingMainChipId` picked "the multi-pin chip with the most power pins on the rail." That's not the same as "the chip being decoupled." On any rail, a **connector** qualifies just as well as the MCU:

```
repro125:  C1, C2  (wired only to net.VDD / net.GND)
           -> grouped to J1, a <pinheader>   ❌
```

A pin header isn't decoupled by anything, so this invented a decoupling group (and a cap row) that never existed before. The knock-on layout churn is what showed up a regressions: in repro125 J2 was shoved aside and its GND label stopped routing; in the RP2040 power-supply section C4/C18 were force-rowed and the D1 → regulator → PWR_LED
path broke.

More fundamentally, none of these caps should have been grouped at all — they're wired net-only with no directly-wired sibling, so before #155 they were placed individually.

## The fix

A rail-only cap decouples the **same chip that a directly-wired sibling cap on the same rail decouples**. So instead of scoring candidate main chips, find a sibling capacitor on the rail and ask *it* for its main chip:

```ts
private findRailSharingMainChipId(capChip, netPair): ChipId | null {
  for (const sibling of Object.values(this.inputProblem.chipMap)) {
    if (sibling.chipId === capChip.chipId) continue
    if (!sibling.isCapacitor) continue
    const siblingPair = this.getNormalizedNetPair(sibling)
    if (!siblingPair || siblingPair[0] !== netPair[0] || siblingPair[1] !== netPair[1]) continue
    return this.findStronglyConnectedMainChipId(sibling) ?? undefined
  }
  return null
}
```

- **rp2040**: C9 (V1_1, net-only) finds sibling C18/C7 (also V1_1), which are wired to U3.DVDD → C9 joins U3. ✅ unchanged
- **repro125**: C1/C2 (VDD, net-only) have no wired sibling on VDD → left ungrouped → matches the pre-#155 layout. ✅
- **connectors**: the loop only ever inspects capacitors, so a pin header can't be returned as a main chip — it's structurally impossible now, not filtered after the fact.

This reuses the existing `findStronglyConnectedMainChipId` and keeps the
`findStronglyConnectedMainChipId() ?? findRailSharingMainChipId()` shape, so there's one
notion of "which chip does a cap decouple," not two. It's also order-independent —
grouping doesn't depend on the order caps are processed (verified with C9 placed first).

<img width="593" height="240" alt="Screenshot 2026-07-12 at 2 25 36 PM" src="https://github.com/user-attachments/assets/8aa11320-d635-44f1-95f7-695074df4106" />

<img width="615" height="400" alt="Screenshot 2026-07-12 at 2 26 10 PM" src="https://github.com/user-attachments/assets/a840323c-7dd0-4300-8ee6-502e2d84342a" />



