### PR TITLE
Update packing and schematic dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@tscircuit/circuit-json-util": "^0.0.95",
     "@tscircuit/math-utils": "^0.0.36",
-    "@tscircuit/schematic-viewer": "^2.0.61",
+    "@tscircuit/schematic-viewer": "^2.0.74",
     "@types/bun": "^1.3.14",
     "bun-match-svg": "^0.0.15",
     "bpc-graph": "^0.0.66",
@@ -30,7 +30,7 @@
     "react-cosmos-plugin-vite": "^7.3.0",
     "tscircuit": "^0.0.1891",
     "tsup": "^8.5.1",
-    "circuit-to-svg": "^0.0.351"
+    "circuit-to-svg": "^0.0.392"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/bun": "^1.3.14",
     "bun-match-svg": "^0.0.15",
     "bpc-graph": "^0.0.66",
-    "calculate-packing": "^0.0.78",
+    "calculate-packing": "^0.0.79",
     "circuit-json": "^0.0.432",
     "graphics-debug": "^0.0.95",
     "react-cosmos": "^7.3.0",


### PR DESCRIPTION
## Summary

- update `calculate-packing` from `^0.0.78` to `^0.0.79`
- update `@tscircuit/schematic-viewer` from `^2.0.61` to `^2.0.74`
- update `circuit-to-svg` from `^0.0.351` to `^0.0.392`

## Why

The packing update keeps matchpack on the latest compatible release. A clean dependency install resolved `@tscircuit/schematic-viewer@2.0.74`, which imports `colorMap`; `circuit-to-svg@0.0.351` did not export it. Updating both schematic packages keeps their runtime APIs compatible and fixes the failing test job.

## Impact

Consumers receive the updated packing implementation and compatible schematic rendering dependencies.

## Validation

- `bun test` — 46 passed, 1 skipped, 0 failed
- `bun run format:check` — passed