### PR TITLE
fix: use declared pin side when grouping same-side passives (#15)

### DIFF
--- a/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
@@ -69,12 +69,28 @@ const getNetForPin = (problem: InputProblem, pinId: PinId): NetId | null => {
   return null
 }
 
-/** Main-chip side a pin offset points to once the chip's rotation is applied. */
+/** Rotate a declared side by a CCW quarter-turn rotation. */
+const SIDE_ROTATION_ORDER: Side[] = ["x+", "y+", "x-", "y-"]
+const rotateSide = (side: Side, ccwRotationDegrees: number): Side => {
+  const turns = ((Math.round(ccwRotationDegrees / 90) % 4) + 4) % 4
+  const index = SIDE_ROTATION_ORDER.indexOf(side)
+  return SIDE_ROTATION_ORDER[(index + turns) % 4]!
+}
+
+/**
+ * Main-chip side a pin sits on once the chip's rotation is applied.
+ *
+ * Prefers the pin's declared `side` — offset inference misclassifies corner
+ * pins (e.g. a left-edge pin near the top of a tall chip has |y| > |x|, which
+ * would wrongly read as "y+") — and falls back to offset inference when no
+ * side is declared.
+ */
 const getMainChipPinSide = (
-  offset: { x: number; y: number },
+  pin: { offset: { x: number; y: number }; side?: Side },
   mainChipRotation: number,
 ): Side => {
-  const o = rotatePinOffset(offset, mainChipRotation)
+  if (pin.side) return rotateSide(pin.side, mainChipRotation)
+  const o = rotatePinOffset(pin.offset, mainChipRotation)
   if (Math.abs(o.x) >= Math.abs(o.y)) {
     if (o.x >= 0) return "x+"
     return "x-"
@@ -164,7 +180,7 @@ export const findSameSidePassiveGroups = (
         commonNodeGroups.push({
           mainChipId,
           side: getMainChipPinSide(
-            mainChipPin.offset,
+            mainChipPin,
             mainChip.availableRotations?.[0] ?? 0,
           ),
           passiveChipIds,
@@ -215,7 +231,7 @@ export const findSameSidePassiveGroups = (
       mainChipRotation,
     )
     const side = getMainChipPinSide(
-      problem.chipPinMap[mainChipPinId]!.offset,
+      problem.chipPinMap[mainChipPinId]!,
       mainChipRotation,
     )
     candidates.push({

--- a/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups-corner-pins.test.ts
+++ b/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups-corner-pins.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import { findSameSidePassiveGroups } from "lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups"
+import { problem } from "../../pages/LayoutPipelineSolver/LayoutPipelineSolver06.page"
+
+// https://github.com/tscircuit/matchpack/issues/15
+//
+// U3's decoupling caps all hang off its LEFT edge (every rail pin declares
+// side "x-"), but side inference from pin offsets misclassified the corner
+// pins: U3.44 sits near the top of the tall chip at offset (-1.9, 2.0), where
+// |y| > |x| reads as "y+". That split the caps into an x- group and a phantom
+// y+ group, so C10/C11/C7/C18 never joined the left-edge rows.
+//
+// The declared pin side is authoritative; offset inference is only a fallback.
+test("corner pins keep their declared side when grouping same-side passives", () => {
+  const groups = findSameSidePassiveGroups(problem as any)
+
+  // All caps must land in x- groups — no phantom y+ group from corner pins
+  expect(groups.every((group) => group.side === "x-")).toBe(true)
+
+  const groupedCaps = new Set(groups.flatMap((group) => group.passiveChipIds))
+  for (const capId of ["C10", "C11", "C7", "C18"]) {
+    expect(groupedCaps.has(capId)).toBe(true)
+  }
+})


### PR DESCRIPTION
Progress on #15 — fixes the corner-pin misgrouping that leaves caps out of the decoupling rows.

## Problem

`findSameSidePassiveGroups` infers a main-chip pin's side from its offset (`|x|` vs `|y|`). On tall chips this misclassifies **corner pins**: on the `LayoutPipelineSolver06` board, `U3.44` is declared `side: "x-"` (left edge) but sits near the top at offset `(-1.9, 2.0)`, where `|y| > |x|` reads as `y+`.

This split U3's decoupling caps into an `x-` group and a phantom `y+` group (`C18, C7, C10` — pins `U3.23/U3.50/U3.44`, all actually left-edge pins). Result on the 06 board: C10 and C11 pack as loose singles floating between the cap rows and U3 instead of joining the rows — the "messy" arrangement in the issue screenshot.

## Fix

The declared `ChipPin.side` is now authoritative (rotated by the chip's fixed rotation); offset inference remains only as a fallback for pins without a declared side.

Before/after grouping on the 06 board:

```
before: {main=U3 side=x- caps=C11,C19,C15,C13,C8,C14,C12} + phantom {main=U3 side=y+ caps=C18,C7,C10}
after:  {main=U3 side=x- caps=C11,C19,C15,C13,C8,C14,C12,C10,C7,C18}
```

## Verification

- New regression test `tests/PackInnerPartitionsSolver/findSameSidePassiveGroups-corner-pins.test.ts` (fails on `main`: phantom `y+` group)
- `bun test` — 56 pass, 0 fail; RP2040 board snapshots unchanged (their rows were already correct and stay byte-identical)
- `bunx tsc --noEmit` / `bun run format:check` — clean

Scoped intentionally small: this fixes the grouping stage only. If you'd like, I can follow up on the row *placement* for the merged group (C10/C11 vertical spread on the 06 board) as a separate PR so each change stays reviewable.
