### PR TITLE
Increase packing iteration limit

### DIFF
--- a/lib/solvers/BaseSolver.ts
+++ b/lib/solvers/BaseSolver.ts
@@ -1,7 +1,7 @@
 import type { GraphicsObject } from "graphics-debug"
 
 export class BaseSolver {
-  MAX_ITERATIONS = 100e3
+  MAX_ITERATIONS = 200e3
   solved = false
   failed = false
   iterations = 0

--- a/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/SingleInnerPartitionPackingSolver.ts
@@ -45,6 +45,7 @@ export class SingleInnerPartitionPackingSolver extends BaseSolver {
 
       const packInput = this.createPackInput(pinToNetworkMap)
       this.activeSubSolver = new PackSolver2(packInput)
+      this.activeSubSolver.MAX_ITERATIONS = this.MAX_ITERATIONS
     }
 
     // Run one step of the PackSolver2

--- a/tests/repros/repro-wled-matrix-iteration-budget.test.ts
+++ b/tests/repros/repro-wled-matrix-iteration-budget.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "bun:test"
+import { LayoutPipelineSolver } from "lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver"
+import type { InputProblem, PinId } from "lib/types/InputProblem"
+
+const LED_COUNT = 12 * 12
+
+const createWledMatrixProblem = (): InputProblem => {
+  const problem: InputProblem = {
+    chipMap: {},
+    chipPinMap: {},
+    netMap: {
+      V5: { netId: "V5", isPositiveVoltageSource: true },
+      GND: { netId: "GND", isGround: true },
+    },
+    pinStrongConnMap: {},
+    netConnMap: {},
+    chipGap: 0.6,
+    decouplingCapsGap: 0.4,
+    partitionGap: 1.2,
+  }
+
+  const connectPins = (firstPinId: PinId, secondPinId: PinId) => {
+    problem.pinStrongConnMap[`${firstPinId}-${secondPinId}`] = true
+    problem.pinStrongConnMap[`${secondPinId}-${firstPinId}`] = true
+  }
+
+  const u1PinIds = Array.from({ length: 14 }, (_, pinIndex) => {
+    const pinNumber = pinIndex + 1
+    const pinId = `U1.${pinNumber}`
+    const isLeftSide = pinNumber <= 7
+    const sidePinIndex = isLeftSide ? pinIndex : pinIndex - 7
+    problem.chipPinMap[pinId] = {
+      pinId,
+      offset: {
+        x: isLeftSide ? -1.45 : 1.45,
+        y: (isLeftSide ? 3 - sidePinIndex : sidePinIndex - 3) * 0.2,
+      },
+      side: isLeftSide ? "x-" : "x+",
+    }
+    return pinId
+  })
+  problem.chipMap.U1 = {
+    chipId: "U1",
+    pins: u1PinIds,
+    size: { x: 2.1, y: 2.4 },
+    availableRotations: [0],
+  }
+
+  problem.chipMap.RDATA = {
+    chipId: "RDATA",
+    pins: ["RDATA.1", "RDATA.2"],
+    size: { x: 0.6, y: 0.68 },
+    isResistor: true,
+    availableRotations: [0, 90, 180, 270],
+  }
+  problem.chipPinMap["RDATA.1"] = {
+    pinId: "RDATA.1",
+    offset: { x: -0.3, y: 0 },
+    side: "x-",
+  }
+  problem.chipPinMap["RDATA.2"] = {
+    pinId: "RDATA.2",
+    offset: { x: 0.3, y: 0 },
+    side: "x+",
+  }
+
+  connectPins("U1.5", "RDATA.1")
+
+  for (let ledIndex = 0; ledIndex < LED_COUNT; ledIndex++) {
+    const chipId = `D${ledIndex + 1}`
+    const pinIds = [1, 2, 3, 4].map((pinNumber) => `${chipId}.${pinNumber}`)
+    problem.chipMap[chipId] = {
+      chipId,
+      pins: pinIds,
+      size: { x: 1.2, y: 1.4 },
+      availableRotations: [0],
+    }
+    problem.chipPinMap[`${chipId}.1`] = {
+      pinId: `${chipId}.1`,
+      offset: { x: -1, y: 0.1 },
+      side: "x-",
+    }
+    problem.chipPinMap[`${chipId}.2`] = {
+      pinId: `${chipId}.2`,
+      offset: { x: -1, y: -0.1 },
+      side: "x-",
+    }
+    problem.chipPinMap[`${chipId}.3`] = {
+      pinId: `${chipId}.3`,
+      offset: { x: 1, y: -0.1 },
+      side: "x+",
+    }
+    problem.chipPinMap[`${chipId}.4`] = {
+      pinId: `${chipId}.4`,
+      offset: { x: 1, y: 0.1 },
+      side: "x+",
+    }
+    problem.netConnMap[`${chipId}.1-V5`] = true
+    problem.netConnMap[`${chipId}.3-GND`] = true
+
+    if (ledIndex === 0) {
+      connectPins("RDATA.2", `${chipId}.4`)
+    } else {
+      connectPins(`D${ledIndex}.2`, `${chipId}.4`)
+    }
+  }
+
+  problem.netConnMap["U1.14-V5"] = true
+  problem.netConnMap["U1.13-GND"] = true
+
+  return problem
+}
+
+test("large WLED chain completes Matchpack layout without exhausting iterations", () => {
+  const problem = createWledMatrixProblem()
+  const solver = new LayoutPipelineSolver(problem)
+
+  solver.solve()
+
+  expect(solver.failed).toBeFalse()
+  expect(solver.solved).toBeTrue()
+  const innerPartitionSolver =
+    solver.packInnerPartitionsSolver!.completedSolvers[0]!
+  expect(innerPartitionSolver.iterations).toBeLessThanOrEqual(
+    innerPartitionSolver.MAX_ITERATIONS,
+  )
+  const outputLayout = solver.getOutputLayout()
+  expect(Object.keys(outputLayout.chipPlacements)).toHaveLength(LED_COUNT + 2)
+  expect(solver.checkForOverlaps(outputLayout)).toEqual([])
+}, 30_000)


### PR DESCRIPTION
## Summary

- increase Matchpack's default solver iteration limit from 100,000 to 200,000
- apply the same limit to the nested `PackSolver2`
- add a regression test for the 12×12 WLED chain

## Why

The WLED circuit creates a large 146-component partition. Its layout is valid, but `PackSolver2` needs more than 100,000 iterations to finish and previously failed with `PackSolver2 ran out of iterations`.

This PR keeps the existing packing strategy and simply gives the solver enough iterations to complete. The regression verifies that all 146 components are placed without overlaps.

## Validation

- `bun test` — 56 passed, 1 skipped
- `bun run build`