### PR TITLE
Add polarized capacitor auto-layout regression

### DIFF
--- a/tests/assets/polarized-capacitor-auto-layout.input.json
+++ b/tests/assets/polarized-capacitor-auto-layout.input.json
@@ -1,0 +1,161 @@
+{
+  "chipMap": {
+    "C1": {
+      "chipId": "C1",
+      "pins": ["C1.2", "C1.1"],
+      "size": {
+        "x": 0.6,
+        "y": 1.1
+      },
+      "isCapacitor": true,
+      "isCrystal": false,
+      "isResistor": false,
+      "isTestPoint": false,
+      "availableRotations": [270]
+    },
+    "C2": {
+      "chipId": "C2",
+      "pins": ["C2.1", "C2.2"],
+      "size": {
+        "x": 0.6,
+        "y": 0.84
+      },
+      "isCapacitor": true,
+      "isCrystal": false,
+      "isResistor": false,
+      "isTestPoint": false,
+      "availableRotations": [270]
+    },
+    "U1": {
+      "chipId": "U1",
+      "pins": ["U1.1", "U1.2", "U1.3", "U1.4", "U1.5", "U1.6", "U1.7", "U1.8"],
+      "size": {
+        "x": 1.6,
+        "y": 1.7999999999999998
+      },
+      "isCapacitor": false,
+      "isCrystal": false,
+      "isResistor": false,
+      "isTestPoint": false,
+      "availableRotations": [0]
+    }
+  },
+  "chipPinMap": {
+    "C1.2": {
+      "pinId": "C1.2",
+      "offset": {
+        "x": 0.3,
+        "y": 3.6739403974420595e-17
+      },
+      "side": "x+"
+    },
+    "C1.1": {
+      "pinId": "C1.1",
+      "offset": {
+        "x": -0.3,
+        "y": -3.6739403974420595e-17
+      },
+      "side": "x-"
+    },
+    "C2.1": {
+      "pinId": "C2.1",
+      "offset": {
+        "x": -0.3,
+        "y": 0
+      },
+      "side": "x-"
+    },
+    "C2.2": {
+      "pinId": "C2.2",
+      "offset": {
+        "x": 0.3,
+        "y": 0
+      },
+      "side": "x+"
+    },
+    "U1.1": {
+      "pinId": "U1.1",
+      "offset": {
+        "x": -1.2000000000000002,
+        "y": 0.30000000000000004
+      },
+      "side": "x-"
+    },
+    "U1.2": {
+      "pinId": "U1.2",
+      "offset": {
+        "x": -1.2000000000000002,
+        "y": 0.10000000000000003
+      },
+      "side": "x-"
+    },
+    "U1.3": {
+      "pinId": "U1.3",
+      "offset": {
+        "x": -1.2000000000000002,
+        "y": -0.09999999999999998
+      },
+      "side": "x-"
+    },
+    "U1.4": {
+      "pinId": "U1.4",
+      "offset": {
+        "x": -1.2000000000000002,
+        "y": -0.30000000000000004
+      },
+      "side": "x-"
+    },
+    "U1.5": {
+      "pinId": "U1.5",
+      "offset": {
+        "x": 1.2000000000000002,
+        "y": -0.30000000000000004
+      },
+      "side": "x+"
+    },
+    "U1.6": {
+      "pinId": "U1.6",
+      "offset": {
+        "x": 1.2000000000000002,
+        "y": -0.10000000000000003
+      },
+      "side": "x+"
+    },
+    "U1.7": {
+      "pinId": "U1.7",
+      "offset": {
+        "x": 1.2000000000000002,
+        "y": 0.09999999999999998
+      },
+      "side": "x+"
+    },
+    "U1.8": {
+      "pinId": "U1.8",
+      "offset": {
+        "x": 1.2000000000000002,
+        "y": 0.30000000000000004
+      },
+      "side": "x+"
+    }
+  },
+  "netMap": {
+    "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1": {
+      "netId": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1",
+      "isGround": true,
+      "isPositiveVoltageSource": false
+    }
+  },
+  "pinStrongConnMap": {
+    "U1.1-C1.1": true,
+    "C1.1-U1.1": true,
+    "U1.1-C2.1": true,
+    "C2.1-U1.1": true
+  },
+  "netConnMap": {
+    "C1.2-unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1": true,
+    "C2.2-unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1": true
+  },
+  "chipGap": 0.6,
+  "decouplingCapsGap": 0.4,
+  "partitionGap": 1.2
+}

--- a/tests/repros/__snapshots__/polarized-capacitor-auto-layout.snap.svg
+++ b/tests/repros/__snapshots__/polarized-capacitor-auto-layout.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-3.79,-0.29999999999999993 -2.22,-0.29999999999999993" data-type="line" data-label="" points="95.5956678700361,350.3249097472924 254.29602888086637,350.3249097472924" fill="none" stroke="rgba(0,0,0,0.1)" stroke-width="1px"/></g><g><polyline data-points="-1.2000000000000002,0.30000000000000004 -3.79,0.30000000000000004" data-type="line" data-label="" points="357.4007220216606,289.6750902527076 95.5956678700361,289.6750902527076" fill="none" stroke="black" stroke-width="1px"/></g><g><polyline data-points="-1.2000000000000002,0.30000000000000004 -2.22,0.30000000000000004" data-type="line" data-label="" points="357.4007220216606,289.6750902527076 254.29602888086637,289.6750902527076" fill="none" stroke="black" stroke-width="1px"/></g><g><rect data-type="rect" data-label="C1" data-x="-3.79" data-y="5.551115123125783e-17" x="40.00000000000003" y="289.6750902527076" width="111.19133574007213" height="60.64981949458479" fill="rgba(59, 130, 246, 0.18)" stroke="none" stroke-width="0.009892857142857142"/></g><g><rect data-type="rect" data-label="C2" data-x="-2.22" data-y="5.551115123125783e-17" x="211.84115523465698" y="289.6750902527076" width="84.90974729241879" height="60.64981949458479" fill="rgba(59, 130, 246, 0.18)" stroke="none" stroke-width="0.009892857142857142"/></g><g><rect data-type="rect" data-label="U1" data-x="0" data-y="0" x="397.8339350180505" y="229.02527075812276" width="161.7328519855596" height="181.94945848375448" fill="rgba(245, 158, 11, 0.18)" stroke="none" stroke-width="0.009892857142857142"/></g><text data-type="text" data-label="C1" data-x="-3.79" data-y="5.551115123125783e-17" x="95.5956678700361" y="320" fill="black" font-size="13.342960288808666" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">C1</text><text data-type="text" data-label="C2" data-x="-2.22" data-y="5.551115123125783e-17" x="254.29602888086637" y="320" fill="black" font-size="13.342960288808666" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">C2</text><text data-type="text" data-label="U1" data-x="0" data-y="0" x="478.7003610108303" y="320" fill="black" font-size="35.37906137184115" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">U1</text><g><circle data-type="point" data-label="C1.2 (unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1)" data-x="-3.79" data-y="-0.29999999999999993" cx="95.5956678700361" cy="350.3249097472924" r="3" fill="black"/></g><g><circle data-type="point" data-label="C1.1" data-x="-3.79" data-y="0.30000000000000004" cx="95.5956678700361" cy="289.6750902527076" r="3" fill="black"/></g><g><circle data-type="point" data-label="C2.1" data-x="-2.22" data-y="0.30000000000000004" cx="254.29602888086637" cy="289.6750902527076" r="3" fill="black"/></g><g><circle data-type="point" data-label="C2.2 (unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1)" data-x="-2.22" data-y="-0.29999999999999993" cx="254.29602888086637" cy="350.3249097472924" r="3" fill="black"/></g><g><circle data-type="point" data-label="U1.1" data-x="-1.2000000000000002" data-y="0.30000000000000004" cx="357.4007220216606" cy="289.6750902527076" r="3" fill="black"/></g><g><circle data-type="point" data-label="U1.2" data-x="-1.2000000000000002" data-y="0.10000000000000003" cx="357.4007220216606" cy="309.8916967509025" r="3" fill="black"/></g><g><circle data-type="point" data-label="U1.3" data-x="-1.2000000000000002" data-y="-0.09999999999999998" cx="357.4007220216606" cy="330.10830324909745" r="3" fill="black"/></g><g><circle data-type="point" data-label="U1.4" data-x="-1.2000000000000002" data-y="-0.30000000000000004" cx="357.4007220216606" cy="350.3249097472924" r="3" fill="black"/></g><g><circle data-type="point" data-label="U1.5" data-x="1.2000000000000002" data-y="-0.30000000000000004" cx="600" cy="350.3249097472924" r="3" fill="black"/></g><g><circle data-type="point" data-label="U1.6" data-x="1.2000000000000002" data-y="-0.10000000000000003" cx="600" cy="330.1083032490975" r="3" fill="black"/></g><g><circle data-type="point" data-label="U1.7" data-x="1.2000000000000002" data-y="0.09999999999999998" cx="600" cy="309.89169675090255" r="3" fill="black"/></g><g><circle data-type="point" data-label="U1.8" data-x="1.2000000000000002" data-y="0.30000000000000004" cx="600" cy="289.6750902527076" r="3" fill="black"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":101.08303249097473,"c":0,"e":478.7003610108303,"b":0,"d":-101.08303249097473,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e;
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repros/polarized-capacitor-auto-layout.test.ts
+++ b/tests/repros/polarized-capacitor-auto-layout.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test"
+import { LayoutPipelineSolver } from "../../lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver"
+import type { InputProblem } from "../../lib/types/InputProblem"
+import input from "../assets/polarized-capacitor-auto-layout.input.json"
+
+test("reproduces polarized capacitor auto-layout", async () => {
+  const solver = new LayoutPipelineSolver(input as InputProblem)
+  solver.solve()
+
+  await expect(solver).toMatchSolverSnapshot(import.meta.path)
+})


### PR DESCRIPTION
### Motivation
- Preserve the auto-layout case where polarized and interchangeable capacitors share chip and ground connections.

### Before
- Matchpack had no focused regression snapshot for this capacitor placement topology.

### After
- Matchpack captures the exact Core input and snapshots the resulting `C1`, `C2`, and `U1` placement.
