### PR TITLE
Fix RP2040 repro type checking

### DIFF
--- a/tests/repros/repro-rp2040-power-supply-section.test.ts
+++ b/tests/repros/repro-rp2040-power-supply-section.test.ts
@@ -8,6 +8,7 @@ import input from "../assets/repro-rp2040-power-supply-section.input.json"
 // Captured from @tscircuit/core 0.0.1539 with @tscircuit/matchpack 0.0.55.
 test("RP2040 power supply section auto-layout", async () => {
   const solver = new LayoutPipelineSolver(input as InputProblem)
+  const chipPinMap = input.chipPinMap as InputProblem["chipPinMap"]
   solver.solve()
 
   const layout = solver.getOutputLayout()
@@ -31,9 +32,9 @@ test("RP2040 power supply section auto-layout", async () => {
     )
     expect(
       getVerticalPinClearanceOffset({
-        upperPin: input.chipPinMap["U2.5"]!,
+        upperPin: chipPinMap["U2.5"]!,
         upperPlacement: u2Placement,
-        lowerPin: input.chipPinMap[`${capacitorId}.1`]!,
+        lowerPin: chipPinMap[`${capacitorId}.1`]!,
         lowerPlacement: capacitorPlacement,
       }),
     ).toBeCloseTo(0)


### PR DESCRIPTION
### Motivation
- Keep the RP2040 power-supply regression test compatible with the typed pin-clearance helper.

### Before
- Type checking failed because JSON pin sides were inferred as strings instead of the `Side` union.

### After
- The imported chip pin map is typed as the input problem pin map before its pins are passed to the helper.
