### PR TITLE
Reuse grounded load pairs during trace offsetting

### DIFF
--- a/lib/solvers/GroundedLoadPairSolver/GroundedLoadPairSolver.ts
+++ b/lib/solvers/GroundedLoadPairSolver/GroundedLoadPairSolver.ts
@@ -44,6 +44,7 @@ export class GroundedLoadPairSolver extends BaseSolver {
       inputProblem: this.params.inputProblem,
     })
     offsetChipAnchoredGroundedLoadConnections({
+      groundedLoadPairs,
       inputProblem: this.params.inputProblem,
       chipPlacements,
     })

--- a/lib/utils/offsetCollinearConnections.ts
+++ b/lib/utils/offsetCollinearConnections.ts
@@ -8,7 +8,7 @@ import type {
 } from "../types/InputProblem"
 import type { Placement } from "../types/OutputLayout"
 import { getRotatedSize, rotatePinOffset } from "./rotatePinOffset"
-import { getGroundedLoadPairs } from "../solvers/GroundedLoadPairSolver/getGroundedLoadPairs"
+import type { GroundedLoadPair } from "../solvers/GroundedLoadPairSolver/getGroundedLoadPairs"
 import { createPinOwnerMap } from "./createPinOwnerMap"
 
 const TRACE_CLEARANCE = 0.2
@@ -234,13 +234,15 @@ export const applyDirectPassiveTraceClearance = ({
 }
 
 export const offsetChipAnchoredGroundedLoadConnections = ({
+  groundedLoadPairs,
   inputProblem,
   chipPlacements,
 }: {
+  groundedLoadPairs: GroundedLoadPair[]
   inputProblem: InputProblem
   chipPlacements: Record<ChipId, Placement>
 }): void => {
-  for (const groundedLoadPair of getGroundedLoadPairs(inputProblem)) {
+  for (const groundedLoadPair of groundedLoadPairs) {
     if (!groundedLoadPair.mainPinId) continue
     if (!groundedLoadPair.upperChip.isResistor) continue
 


### PR DESCRIPTION
### Motivation
- Avoid repeating grounded-load discovery during the same solver phase.

### Before
- Grounded-load pairs were rediscovered while offsetting chip-anchored connections.

### After
- The previously discovered grounded-load pairs are reused during connection offsetting.