### PR TITLE
Clear grounded load pairs from bodies level with the pair

### DIFF
--- a/lib/solvers/GroundedLoadPairSolver/layoutGroundedLoadPair.ts
+++ b/lib/solvers/GroundedLoadPairSolver/layoutGroundedLoadPair.ts
@@ -107,7 +107,12 @@ const movePairBelowObstacles = ({
       pairBounds.maxX + inputProblem.chipGap <= bounds.minX ||
       pairBounds.minX - inputProblem.chipGap >= bounds.maxX
     if (clearsPairOnX) continue
-    if (bounds.maxY <= pairBounds.maxY) continue
+    // Skip bodies that already sit entirely below the pair. Shifting the pair
+    // further down moves it toward those, not away. Any body that overlaps the
+    // pair's vertical span still has to be cleared, including one placed level
+    // with the pair (its top at or below the pair top), which the previous
+    // `bounds.maxY <= pairBounds.maxY` guard dropped and left overlapping.
+    if (bounds.maxY <= pairBounds.minY) continue
 
     const requiredShift = pairBounds.maxY + inputProblem.chipGap - bounds.minY
     downwardShift = Math.max(downwardShift, requiredShift)

--- a/tests/repros/repro-grounded-load-pair-neighbor-overlap.test.ts
+++ b/tests/repros/repro-grounded-load-pair-neighbor-overlap.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { LayoutPipelineSolver } from "lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver"
+import type { InputProblem } from "lib/types/InputProblem"
+import repro44Input from "../assets/repro44-e2e-pack-and-schematic.input.json"
+
+// Regression for a grounded load pair being stacked on top of a neighbouring chip.
+//
+// GroundedLoadPairSolver re-stacks each grounded two-component chain vertically
+// under its main-chip pin, then drops the pair down to clear bodies that sit in
+// its column. The clearance pass only accounted for bodies whose top edge was
+// above the pair's top edge, so a chip that ended up level with the pair (top at
+// or below the pair top) was skipped and left overlapping.
+//
+// This fixture is the repro44 e2e circuit with the requested chip gap widened to
+// 1. At that gap the packer parks R2 level with the R3/D1 grounded load pair, and
+// the pair used to land directly on top of R2. A larger requested gap must never
+// produce overlapping chips.
+test("grounded load pair does not overlap a neighbour level with it", () => {
+  const inputProblem = structuredClone(repro44Input) as InputProblem
+  inputProblem.chipGap = 1
+
+  const solver = new LayoutPipelineSolver(inputProblem)
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+
+  const outputLayout = solver.getOutputLayout()
+  const overlaps = solver.checkForOverlaps(outputLayout)
+  expect(overlaps).toHaveLength(0)
+})


### PR DESCRIPTION
## What

`GroundedLoadPairSolver` re-stacks each grounded two-component load chain (a two-pin part feeding another two-pin part down to ground) vertically under its main-chip pin, then calls `movePairBelowObstacles` to drop the pair down until it clears any body sitting in its column.

That clearance pass used the wrong guard. It only treated a body as an obstacle when the body's top edge was above the pair's top edge:

```ts
if (bounds.maxY <= pairBounds.maxY) continue
```

A body that ended up level with the pair (its top at or below the pair top) was skipped even when it overlapped the pair, so the pair was left sitting on top of it.

## Repro

`tests/repros/repro-grounded-load-pair-neighbor-overlap.test.ts` runs the existing repro44 e2e circuit with the requested `chipGap` widened to 1. At that gap the packer parks R2 level with the R3/D1 grounded load pair. Before this change the pair landed directly on top of R2, an overlap of about 0.29 in area. A larger requested gap producing overlapping chips is clearly wrong.

This is not specific to repro44. I found it by widening `chipGap` on the fixtures, then reproduced the same guard failing on many small generated circuits at the default `chipGap` of 0.2.

## Fix

Skip a body only when it already sits entirely below the pair, since dropping the pair further would move it toward that body rather than clear it. Any body that still overlaps the pair's vertical span, including one level with the pair, is now cleared:

```ts
if (bounds.maxY <= pairBounds.minY) continue
```

## Verification

On this branch:

- `bun test`: 90 pass, 1 skip, 0 fail. The new repro fails without the fix and passes with it.
- `bunx tsc --noEmit`: clean.
- `bun run format:check`: clean.

No existing snapshots changed.

## AI assistance

I authored and verified this change. AI assistance (Claude, Anthropic) was used while writing the fix and the test. I reviewed the diff and traced the overlap through the pipeline to `GroundedLoadPairSolver`, then verified locally before submitting. `bun test`, `bunx tsc --noEmit` and `bun run format:check` all pass.
