### PR TITLE
Preserve grounded load alignment with unrelated chips

### DIFF
--- a/lib/solvers/GroundedLoadPairSolver/alignStandaloneGroundedLoadPairs.ts
+++ b/lib/solvers/GroundedLoadPairSolver/alignStandaloneGroundedLoadPairs.ts
@@ -4,8 +4,6 @@ import type { Placement } from "../../types/OutputLayout"
 import { getRotatedSize } from "../../utils/rotatePinOffset"
 import type { GroundedLoadPair } from "./getGroundedLoadPairs"
 
-const CHIPS_PER_PAIR = 2
-
 const getChipBounds = ({
   chipId,
   chipPlacements,
@@ -66,12 +64,6 @@ export const alignStandaloneGroundedLoadPairs = ({
   )
   const firstPair = standalonePairs[0]
   if (!firstPair || standalonePairs.length < 2) return
-  if (
-    standalonePairs.length * CHIPS_PER_PAIR !==
-    Object.keys(inputProblem.chipMap).length
-  ) {
-    return
-  }
 
   const firstUpperPlacement = chipPlacements[firstPair.upperChip.chipId]
   if (!firstUpperPlacement) return

--- a/tests/assets/repro-grounded-load-pairs-with-unrelated-chip.input.json
+++ b/tests/assets/repro-grounded-load-pairs-with-unrelated-chip.input.json
@@ -1,0 +1,135 @@
+{
+  "chipMap": {
+    "LED1": {
+      "chipId": "LED1",
+      "pins": ["LED1.1", "LED1.2"],
+      "size": { "x": 1.13, "y": 1.18 },
+      "isCapacitor": false,
+      "isCrystal": false,
+      "isResistor": false,
+      "isTestPoint": false,
+      "availableRotations": [0, 90, 180, 270]
+    },
+    "LED2": {
+      "chipId": "LED2",
+      "pins": ["LED2.1", "LED2.2"],
+      "size": { "x": 1.13, "y": 1.18 },
+      "isCapacitor": false,
+      "isCrystal": false,
+      "isResistor": false,
+      "isTestPoint": false,
+      "availableRotations": [0, 90, 180, 270]
+    },
+    "R1": {
+      "chipId": "R1",
+      "pins": ["R1.1", "R1.2"],
+      "size": { "x": 0.6, "y": 0.68 },
+      "isCapacitor": false,
+      "isCrystal": false,
+      "isResistor": true,
+      "isTestPoint": false,
+      "availableRotations": [90]
+    },
+    "R2": {
+      "chipId": "R2",
+      "pins": ["R2.1", "R2.2"],
+      "size": { "x": 0.6, "y": 0.68 },
+      "isCapacitor": false,
+      "isCrystal": false,
+      "isResistor": true,
+      "isTestPoint": false,
+      "availableRotations": [90]
+    },
+    "C_EXTRA": {
+      "chipId": "C_EXTRA",
+      "pins": ["C_EXTRA.1", "C_EXTRA.2"],
+      "size": { "x": 0.8, "y": 0.5 },
+      "isCapacitor": true,
+      "isCrystal": false,
+      "isResistor": false,
+      "isTestPoint": false,
+      "availableRotations": [0, 90],
+      "fixedPosition": { "x": 10, "y": 10 }
+    }
+  },
+  "chipPinMap": {
+    "LED1.1": {
+      "pinId": "LED1.1",
+      "offset": { "x": -0.54, "y": 0 },
+      "side": "x-"
+    },
+    "LED1.2": {
+      "pinId": "LED1.2",
+      "offset": { "x": 0.54, "y": 0 },
+      "side": "x+"
+    },
+    "LED2.1": {
+      "pinId": "LED2.1",
+      "offset": { "x": -0.54, "y": 0 },
+      "side": "x-"
+    },
+    "LED2.2": {
+      "pinId": "LED2.2",
+      "offset": { "x": 0.54, "y": 0 },
+      "side": "x+"
+    },
+    "R1.1": { "pinId": "R1.1", "offset": { "x": -0.3, "y": 0 }, "side": "x-" },
+    "R1.2": { "pinId": "R1.2", "offset": { "x": 0.3, "y": 0 }, "side": "x+" },
+    "R2.1": { "pinId": "R2.1", "offset": { "x": -0.3, "y": 0 }, "side": "x-" },
+    "R2.2": { "pinId": "R2.2", "offset": { "x": 0.3, "y": 0 }, "side": "x+" },
+    "C_EXTRA.1": {
+      "pinId": "C_EXTRA.1",
+      "offset": { "x": -0.4, "y": 0 },
+      "side": "x-"
+    },
+    "C_EXTRA.2": {
+      "pinId": "C_EXTRA.2",
+      "offset": { "x": 0.4, "y": 0 },
+      "side": "x+"
+    }
+  },
+  "netMap": {
+    "SIG1": {
+      "netId": "SIG1",
+      "isGround": false,
+      "isPositiveVoltageSource": false
+    },
+    "SIG2": {
+      "netId": "SIG2",
+      "isGround": false,
+      "isPositiveVoltageSource": false
+    },
+    "GND": {
+      "netId": "GND",
+      "isGround": true,
+      "isPositiveVoltageSource": false
+    },
+    "EXTRA1": {
+      "netId": "EXTRA1",
+      "isGround": false,
+      "isPositiveVoltageSource": false
+    },
+    "EXTRA2": {
+      "netId": "EXTRA2",
+      "isGround": false,
+      "isPositiveVoltageSource": false
+    }
+  },
+  "pinStrongConnMap": {
+    "LED1.1-R1.2": true,
+    "R1.2-LED1.1": true,
+    "LED2.1-R2.2": true,
+    "R2.2-LED2.1": true
+  },
+  "netConnMap": {
+    "LED1.2-SIG1": true,
+    "LED2.2-SIG2": true,
+    "R1.1-GND": true,
+    "R2.1-GND": true,
+    "C_EXTRA.1-EXTRA1": true,
+    "C_EXTRA.2-EXTRA2": true
+  },
+  "chipGap": 0.6,
+  "decouplingCapsGap": 0.4,
+  "partitionGap": 1.2
+}

--- a/tests/repros/__snapshots__/repro-grounded-load-pairs-with-unrelated-chip.snap.svg
+++ b/tests/repros/__snapshots__/repro-grounded-load-pairs-with-unrelated-chip.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="9.8875,6.772500000000002 12.267499999999998,6.772500000000002" data-type="line" data-label="" points="132.8089887640449,593.511235955056 507.1910112359551,593.511235955056" fill="none" stroke="rgba(0,0,0,0.1)" stroke-width="1px"/></g><g><polyline data-points="9.8875,7.997500000000001 9.8875,7.372500000000001" data-type="line" data-label="" points="132.8089887640449,400.8146067415728 132.8089887640449,499.12921348314603" fill="none" stroke="black" stroke-width="1px"/></g><g><polyline data-points="12.267499999999998,7.997500000000001 12.267499999999998,7.372500000000001" data-type="line" data-label="" points="507.1910112359551,400.8146067415728 507.1910112359551,499.12921348314603" fill="none" stroke="black" stroke-width="1px"/></g><g><rect data-type="rect" data-label="LED1" data-x="9.8875" data-y="8.537500000000001" x="40" y="226.99438202247165" width="185.6179775280898" height="177.75280898876417" fill="rgba(168, 85, 247, 0.18)" stroke="none" stroke-width="0.006357142857142855"/></g><g><rect data-type="rect" data-label="LED2" data-x="12.267499999999998" data-y="8.537500000000001" x="414.3820224719101" y="226.99438202247165" width="185.61797752809002" height="177.75280898876417" fill="rgba(168, 85, 247, 0.18)" stroke="none" stroke-width="0.006357142857142855"/></g><g><rect data-type="rect" data-label="R1" data-x="9.8875" data-y="7.072500000000002" x="79.32584269662925" y="499.1292134831459" width="106.96629213483129" height="94.38202247190998" fill="rgba(16, 185, 129, 0.18)" stroke="none" stroke-width="0.006357142857142855"/></g><g><rect data-type="rect" data-label="R2" data-x="12.267499999999998" data-y="7.072500000000002" x="453.70786516853934" y="499.1292134831459" width="106.96629213483152" height="94.38202247190998" fill="rgba(16, 185, 129, 0.18)" stroke="none" stroke-width="0.006357142857142855"/></g><g><rect data-type="rect" data-label="C_EXTRA [fixed]" data-x="10" data-y="10" x="87.58426966292132" y="46.488764044943764" width="125.8426966292136" height="78.6516853932585" fill="rgba(30, 64, 175, 0.35)" stroke="none" stroke-width="0.006357142857142855"/></g><text data-type="text" data-label="LED1" data-x="9.8875" data-y="8.537500000000001" x="132.8089887640449" y="315.87078651685374" fill="black" font-size="39.105617977528105" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">LED1</text><text data-type="text" data-label="LED2" data-x="12.267499999999998" data-y="8.537500000000001" x="507.1910112359551" y="315.87078651685374" fill="black" font-size="39.105617977528105" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">LED2</text><text data-type="text" data-label="R1" data-x="9.8875" data-y="7.072500000000002" x="132.8089887640449" y="546.3202247191009" fill="black" font-size="20.764044943820235" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">R1</text><text data-type="text" data-label="R2" data-x="12.267499999999998" data-y="7.072500000000002" x="507.1910112359551" y="546.3202247191009" fill="black" font-size="20.764044943820235" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">R2</text><text data-type="text" data-label="C_EXTRA [fixed]" data-x="10" data-y="10" x="150.50561797752812" y="85.81460674157302" fill="black" font-size="17.30337078651686" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">C_EXTRA [fixed]</text><g><circle data-type="point" data-label="LED1.1" data-x="9.8875" data-y="7.997500000000001" cx="132.8089887640449" cy="400.8146067415728" r="3" fill="black"/></g><g><circle data-type="point" data-label="LED1.2 (SIG1)" data-x="9.8875" data-y="9.0775" cx="132.8089887640449" cy="230.9269662921347" r="3" fill="black"/></g><g><circle data-type="point" data-label="LED2.1" data-x="12.267499999999998" data-y="7.997500000000001" cx="507.1910112359551" cy="400.8146067415728" r="3" fill="black"/></g><g><circle data-type="point" data-label="LED2.2 (SIG2)" data-x="12.267499999999998" data-y="9.0775" cx="507.1910112359551" cy="230.9269662921347" r="3" fill="black"/></g><g><circle data-type="point" data-label="R1.1 (GND)" data-x="9.8875" data-y="6.772500000000002" cx="132.8089887640449" cy="593.511235955056" r="3" fill="black"/></g><g><circle data-type="point" data-label="R1.2" data-x="9.8875" data-y="7.372500000000001" cx="132.8089887640449" cy="499.12921348314603" r="3" fill="black"/></g><g><circle data-type="point" data-label="R2.1 (GND)" data-x="12.267499999999998" data-y="6.772500000000002" cx="507.1910112359551" cy="593.511235955056" r="3" fill="black"/></g><g><circle data-type="point" data-label="R2.2" data-x="12.267499999999998" data-y="7.372500000000001" cx="507.1910112359551" cy="499.12921348314603" r="3" fill="black"/></g><g><circle data-type="point" data-label="C_EXTRA.1 (EXTRA1)" data-x="9.6" data-y="10" cx="87.58426966292132" cy="85.81460674157302" r="3" fill="black"/></g><g><circle data-type="point" data-label="C_EXTRA.2 (EXTRA2)" data-x="10.4" data-y="10" cx="213.42696629213492" cy="85.81460674157302" r="3" fill="black"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":157.30337078651692,"c":0,"e":-1422.528089887641,"b":0,"d":-157.30337078651692,"f":1658.8483146067422};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repros/debug-leds-section.test.ts
+++ b/tests/repros/debug-leds-section.test.ts
@@ -21,3 +21,53 @@ test("reproduces debug LEDs section layout", async () => {
 
   await expect(solver).toMatchSolverSnapshot(import.meta.path)
 })
+
+test("aligns grounded load rows when an unrelated chip is present", () => {
+  const inputWithUnrelatedChip = structuredClone(input) as InputProblem
+  inputWithUnrelatedChip.chipMap.C_EXTRA = {
+    chipId: "C_EXTRA",
+    pins: ["C_EXTRA.1", "C_EXTRA.2"],
+    size: { x: 0.8, y: 0.5 },
+    isCapacitor: true,
+    availableRotations: [0, 90],
+    fixedPosition: { x: 10, y: 10 },
+  }
+  inputWithUnrelatedChip.chipPinMap["C_EXTRA.1"] = {
+    pinId: "C_EXTRA.1",
+    offset: { x: -0.4, y: 0 },
+    side: "x-",
+  }
+  inputWithUnrelatedChip.chipPinMap["C_EXTRA.2"] = {
+    pinId: "C_EXTRA.2",
+    offset: { x: 0.4, y: 0 },
+    side: "x+",
+  }
+  inputWithUnrelatedChip.netMap.EXTRA1 = {
+    netId: "EXTRA1",
+    isGround: false,
+    isPositiveVoltageSource: false,
+  }
+  inputWithUnrelatedChip.netMap.EXTRA2 = {
+    netId: "EXTRA2",
+    isGround: false,
+    isPositiveVoltageSource: false,
+  }
+  inputWithUnrelatedChip.netConnMap["C_EXTRA.1-EXTRA1"] = true
+  inputWithUnrelatedChip.netConnMap["C_EXTRA.2-EXTRA2"] = true
+
+  const solver = new LayoutPipelineSolver(inputWithUnrelatedChip)
+  solver.solve()
+
+  const placements = solver.getOutputLayout().chipPlacements
+  for (const [ledId, resistorId] of [
+    ["LED4", "R15"],
+    ["LED5", "R16"],
+    ["LED6", "R17"],
+  ] as const) {
+    expect(placements[ledId]!.x).toBeCloseTo(placements[resistorId]!.x)
+    expect(placements[ledId]!.y).toBeGreaterThan(placements[resistorId]!.y)
+  }
+  expect(placements.LED4!.y).toBeCloseTo(placements.LED5!.y)
+  expect(placements.LED5!.y).toBeCloseTo(placements.LED6!.y)
+  expect(placements.C_EXTRA).toMatchObject({ x: 10, y: 10 })
+})

--- a/tests/repros/repro-grounded-load-pairs-with-unrelated-chip.test.ts
+++ b/tests/repros/repro-grounded-load-pairs-with-unrelated-chip.test.ts
@@ -1,23 +1,26 @@
 import { expect, test } from "bun:test"
 import { LayoutPipelineSolver } from "../../lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver"
 import type { InputProblem } from "../../lib/types/InputProblem"
-import input from "../assets/debug-leds-section.input.json"
+import input from "../assets/repro-grounded-load-pairs-with-unrelated-chip.input.json"
 
-test("reproduces debug LEDs section layout", async () => {
+test("preserves grounded load row alignment with an unrelated chip", async () => {
   const solver = new LayoutPipelineSolver(input as InputProblem)
   solver.solve()
 
   const placements = solver.getOutputLayout().chipPlacements
+
   for (const [ledId, resistorId] of [
-    ["LED4", "R15"],
-    ["LED5", "R16"],
-    ["LED6", "R17"],
+    ["LED1", "R1"],
+    ["LED2", "R2"],
   ] as const) {
     expect(placements[ledId]!.x).toBeCloseTo(placements[resistorId]!.x)
     expect(placements[ledId]!.y).toBeGreaterThan(placements[resistorId]!.y)
   }
-  expect(placements.LED4!.y).toBeCloseTo(placements.LED5!.y)
-  expect(placements.LED5!.y).toBeCloseTo(placements.LED6!.y)
+
+  expect(placements.LED1!.y).toBeCloseTo(placements.LED2!.y)
+  expect(placements.R1!.y).toBeCloseTo(placements.R2!.y)
+  expect(placements.LED1!.x).not.toBeCloseTo(placements.LED2!.x)
+  expect(placements.C_EXTRA).toMatchObject({ x: 10, y: 10 })
 
   await expect(solver).toMatchSolverSnapshot(import.meta.path)
 })


### PR DESCRIPTION
## Summary

- preserve horizontal row alignment for standalone grounded-load pairs when unrelated chips are present
- add regression coverage using the existing debug LED fixture plus an unrelated fixed capacitor
- verify that the unrelated chip keeps its fixed placement

## Why

Adding an electrically unrelated component changed the relative layout of otherwise unchanged signal-to-LED-to-resistor-to-ground chains. The pairs were stacked vertically instead of remaining as vertical pairs arranged in a horizontal row.

## Root cause

`alignStandaloneGroundedLoadPairs` returned early unless every chip in the input belonged to a standalone grounded-load pair. That circuit-wide eligibility check caused any unrelated chip to disable alignment for all valid pairs.


Before:
<img width="1440" height="900" alt="Screenshot 2026-08-08 at 10 59 00 PM" src="https://github.com/user-attachments/assets/bd9c2973-7741-49f3-b1f2-a5b501ffd03f" />

After:
<img width="1440" height="900" alt="Screenshot 2026-08-08 at 11 15 56 PM" src="https://github.com/user-attachments/assets/e836bed1-4cf8-49f3-8449-6ee6bcec10e3" />
 

