### PR TITLE
fix: return stable layout solver name

### DIFF
--- a/lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver.ts
+++ b/lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver.ts
@@ -56,7 +56,9 @@ function definePipelineStep<
 }
 
 export class LayoutPipelineSolver extends BaseSolver {
-  static solverName = "LayoutPipelineSolver"
+  getSolverName(): string {
+    return "LayoutPipelineSolver"
+  }
 
   identifyCrystalCircuitsSolver?: IdentifyCrystalCircuitsSolver
   identifyDecouplingCapsSolver?: IdentifyDecouplingCapsSolver

--- a/lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver.ts
+++ b/lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver.ts
@@ -56,6 +56,8 @@ function definePipelineStep<
 }
 
 export class LayoutPipelineSolver extends BaseSolver {
+  static solverName = "LayoutPipelineSolver"
+
   identifyCrystalCircuitsSolver?: IdentifyCrystalCircuitsSolver
   identifyDecouplingCapsSolver?: IdentifyDecouplingCapsSolver
   chipPartitionsSolver?: ChipPartitionsSolver

--- a/tests/solver-name.test.ts
+++ b/tests/solver-name.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "bun:test"
+import { LayoutPipelineSolver } from "../lib"
+
+test("LayoutPipelineSolver has a stable solver name", () => {
+  expect(LayoutPipelineSolver.solverName).toBe("LayoutPipelineSolver")
+})

--- a/tests/solver-name.test.ts
+++ b/tests/solver-name.test.ts
@@ -2,5 +2,9 @@ import { expect, test } from "bun:test"
 import { LayoutPipelineSolver } from "../lib"
 
 test("LayoutPipelineSolver has a stable solver name", () => {
-  expect(LayoutPipelineSolver.solverName).toBe("LayoutPipelineSolver")
+  const solver = Object.create(
+    LayoutPipelineSolver.prototype,
+  ) as LayoutPipelineSolver
+
+  expect(solver.getSolverName()).toBe("LayoutPipelineSolver")
 })


### PR DESCRIPTION
## Summary
- override getSolverName() on LayoutPipelineSolver
- return a literal name that survives class-name minification
- cover the public solver export with a focused regression test

## Why
solver-utils already uses the instance getSolverName() method throughout GenericSolverDebugger. Returning the readable name from the source solver avoids static metadata and constructor wrappers in core.

## Verification
- bun test tests/solver-name.test.ts
- bunx tsc --noEmit
- bun run build
- bun run format:check