### PR TITLE
ci: migrate npm publishing to OIDC

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -4,25 +4,28 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: pver release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "main": "dist/index.js",
   "type": "module",
   "version": "0.0.84",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tscircuit/matchpack"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary
- grant GitHub Actions OIDC publish permission
- update the Node setup used for npm trusted publishing
- remove the npm token from the release step
- add canonical repository metadata when missing

The matching npm trusted publisher will use organization `tscircuit`, repository `matchpack`, and workflow `bun-pver-release.yml`.