### PR TITLE
fix: align passive rail-carrier groups

### DIFF
--- a/lib/solvers/PackInnerPartitionsSolver/ParallelAlignedPassiveSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/ParallelAlignedPassiveSolver.ts
@@ -227,7 +227,7 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
       })
     }
 
-    const carrierCandidate = this.placeRailCarrier({
+    const carrierCandidates = this.getRailCarrierPlacementCandidates({
       candidatePlacements,
       carrierChipId: railCarrier.carrierChipId,
       carrierPinIdsByPassiveChipId: railCarrier.carrierPinIdsByPassiveChipId,
@@ -238,26 +238,33 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
       outwardAxis,
       alignAxis,
     })
-    if (!carrierCandidate) return
-    candidatePlacements[railCarrier.carrierChipId] = carrierCandidate
+    if (carrierCandidates.length === 0) return
 
     const movedChipIds = [
       ...passiveGroup.passiveChipIds,
       railCarrier.carrierChipId,
     ]
-    if (
-      this.hasChipGapViolationAfterMove(
-        candidatePlacements,
-        placements,
-        movedChipIds,
-        gap,
-      )
-    ) {
-      return
-    }
 
-    for (const chipId of movedChipIds) {
-      placements[chipId] = candidatePlacements[chipId]!
+    for (const carrierCandidate of carrierCandidates) {
+      const completeCandidatePlacements = {
+        ...candidatePlacements,
+        [railCarrier.carrierChipId]: carrierCandidate,
+      }
+      if (
+        this.hasChipGapViolationAfterMove(
+          completeCandidatePlacements,
+          placements,
+          movedChipIds,
+          gap,
+        )
+      ) {
+        continue
+      }
+
+      for (const chipId of movedChipIds) {
+        placements[chipId] = completeCandidatePlacements[chipId]!
+      }
+      return
     }
   }
 
@@ -298,7 +305,7 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
     }
   }
 
-  private placeRailCarrier({
+  private getRailCarrierPlacementCandidates({
     candidatePlacements,
     carrierChipId,
     carrierPinIdsByPassiveChipId,
@@ -318,10 +325,10 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
     baseCarrierPlacement: Placement
     outwardAxis: "x" | "y"
     alignAxis: "x" | "y"
-  }): Placement | null {
+  }): Placement[] {
     const prob = this.partitionInputProblem
     const carrierChip = prob.chipMap[carrierChipId]
-    if (!carrierChip) return null
+    if (!carrierChip) return []
 
     const passiveBounds = getBoundsFromPoints(
       passiveChipIds.flatMap((chipId) => {
@@ -332,12 +339,12 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
         ]
       }),
     )
-    if (!passiveBounds) return null
+    if (!passiveBounds) return []
 
     const rotations = carrierChip.availableRotations ?? [
       baseCarrierPlacement.ccwRotationDegrees,
     ]
-    let bestCandidate: { placement: Placement; score: number } | null = null
+    const candidates: Array<{ placement: Placement; score: number }> = []
 
     for (const ccwRotationDegrees of rotations) {
       const offsets = passiveChipIds.map((passiveChipId) => {
@@ -415,12 +422,16 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
         placement[outwardAxis] - getBoundsCenter(passiveBounds)[outwardAxis],
       )
       const score = maxAlignmentError * 100 + outwardDistance
-      if (!bestCandidate || score < bestCandidate.score) {
-        bestCandidate = { placement, score }
-      }
+      candidates.push({ placement, score })
     }
 
-    return bestCandidate?.placement ?? null
+    candidates.sort((a, b) => {
+      const scoreDelta = a.score - b.score
+      if (scoreDelta !== 0) return scoreDelta
+      return a.placement.ccwRotationDegrees - b.placement.ccwRotationDegrees
+    })
+
+    return candidates.map((candidate) => candidate.placement)
   }
 
   private movePastEarlierGroupOverlaps({

--- a/lib/solvers/PackInnerPartitionsSolver/ParallelAlignedPassiveSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/ParallelAlignedPassiveSolver.ts
@@ -38,6 +38,7 @@ import { SingleInnerPartitionPackingSolver } from "./SingleInnerPartitionPacking
 import {
   type Bounds,
   boundsDistance,
+  doBoundsOverlap,
   getBoundsCenter,
   getBoundsFromPoints,
 } from "@tscircuit/math-utils"
@@ -109,17 +110,331 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
     }
     const passiveGroups = findSameSidePassiveGroups(this.partitionInputProblem)
     for (const passiveGroup of passiveGroups) {
-      this.reflowPassiveGroup(placements, passiveGroup)
+      if (passiveGroup.railCarrier) {
+        this.reflowRailCarrierPassiveGroup(placements, passiveGroup)
+      } else {
+        this.reflowPassiveGroup(placements, passiveGroup)
+      }
     }
     applyDirectPassiveTraceClearance({
       inputProblem: this.partitionInputProblem,
       connectedPinsByPinId: this.pinIdToStronglyConnectedPins,
       chipPlacements: placements,
-      rigidChipGroups: passiveGroups.map(
-        (passiveGroup) => passiveGroup.passiveChipIds,
-      ),
+      rigidChipGroups: passiveGroups.map((passiveGroup) => [
+        ...passiveGroup.passiveChipIds,
+        ...(passiveGroup.railCarrier
+          ? [passiveGroup.railCarrier.carrierChipId]
+          : []),
+      ]),
     })
     return { chipPlacements: placements, groupPlacements: base.groupPlacements }
+  }
+
+  private reflowRailCarrierPassiveGroup(
+    placements: Record<ChipId, Placement>,
+    passiveGroup: SameSidePassiveGroup,
+  ): void {
+    const railCarrier = passiveGroup.railCarrier
+    if (!railCarrier) return
+
+    const prob = this.partitionInputProblem
+    const gap = prob.chipGap
+    const mainChipPlacement = placements[passiveGroup.mainChipId]
+    const carrierPlacement = placements[railCarrier.carrierChipId]
+    const carrierChip = prob.chipMap[railCarrier.carrierChipId]
+    if (!mainChipPlacement || !carrierPlacement || !carrierChip) return
+
+    const outward = OUTWARD_BY_SIDE[passiveGroup.side]
+    const outwardAxis: "x" | "y" = outward.x === 0 ? "y" : "x"
+    const alignAxis: "x" | "y" = outwardAxis === "x" ? "y" : "x"
+    const mainChipBox = this.boxFor(passiveGroup.mainChipId, mainChipPlacement)
+    const candidatePlacements: Record<ChipId, Placement> = {}
+
+    for (const [
+      index,
+      passiveChipId,
+    ] of passiveGroup.passiveChipIds.entries()) {
+      const passiveChip = prob.chipMap[passiveChipId]
+      const packedPlacement = placements[passiveChipId]
+      const mainPinId = passiveGroup.mainChipPinIds[index]
+      const passiveMainPinId =
+        railCarrier.passiveMainPinIdsByChipId[passiveChipId]
+      if (!passiveChip || !packedPlacement || !mainPinId || !passiveMainPinId) {
+        return
+      }
+
+      const mainPinPosition = this.pinPosition(
+        passiveGroup.mainChipId,
+        mainPinId,
+        mainChipPlacement,
+      )
+      const passiveMainPin = prob.chipPinMap[passiveMainPinId]
+      if (!mainPinPosition || !passiveMainPin) return
+
+      const passiveSize = getRotatedSize(
+        passiveChip.size,
+        packedPlacement.ccwRotationDegrees,
+      )
+      const passiveMainPinOffset = rotatePinOffset(
+        passiveMainPin.offset,
+        packedPlacement.ccwRotationDegrees,
+      )
+      const nextPlacement: Placement = {
+        ...packedPlacement,
+        [alignAxis]:
+          mainPinPosition[alignAxis] - passiveMainPinOffset[alignAxis],
+      }
+      if (passiveGroup.side === "x+") {
+        nextPlacement.x = mainChipBox.maxX + gap + passiveSize.x / 2
+      } else if (passiveGroup.side === "x-") {
+        nextPlacement.x = mainChipBox.minX - gap - passiveSize.x / 2
+      } else if (passiveGroup.side === "y+") {
+        nextPlacement.y = mainChipBox.maxY + gap + passiveSize.y / 2
+      } else {
+        nextPlacement.y = mainChipBox.minY - gap - passiveSize.y / 2
+      }
+      candidatePlacements[passiveChipId] = nextPlacement
+      this.movePastEarlierGroupOverlaps({
+        candidatePlacements,
+        chipId: passiveChipId,
+        previousChipIds: passiveGroup.passiveChipIds.slice(0, index),
+        outwardAxis,
+        outwardSign: outward[outwardAxis],
+      })
+    }
+
+    const carrierCandidate = this.placeRailCarrier({
+      candidatePlacements,
+      carrierChipId: railCarrier.carrierChipId,
+      carrierPinIdsByPassiveChipId: railCarrier.carrierPinIdsByPassiveChipId,
+      passiveCarrierPinIdsByChipId: railCarrier.passiveCarrierPinIdsByChipId,
+      passiveChipIds: passiveGroup.passiveChipIds,
+      side: passiveGroup.side,
+      baseCarrierPlacement: carrierPlacement,
+      outwardAxis,
+      alignAxis,
+    })
+    if (!carrierCandidate) return
+    candidatePlacements[railCarrier.carrierChipId] = carrierCandidate
+
+    const movedChipIds = [
+      ...passiveGroup.passiveChipIds,
+      railCarrier.carrierChipId,
+    ]
+    if (
+      this.hasAnyOverlapAfterMove(candidatePlacements, placements, movedChipIds)
+    ) {
+      return
+    }
+
+    for (const chipId of movedChipIds) {
+      placements[chipId] = candidatePlacements[chipId]!
+    }
+  }
+
+  private placeRailCarrier({
+    candidatePlacements,
+    carrierChipId,
+    carrierPinIdsByPassiveChipId,
+    passiveCarrierPinIdsByChipId,
+    passiveChipIds,
+    side,
+    baseCarrierPlacement,
+    outwardAxis,
+    alignAxis,
+  }: {
+    candidatePlacements: Record<ChipId, Placement>
+    carrierChipId: ChipId
+    carrierPinIdsByPassiveChipId: Record<ChipId, PinId>
+    passiveCarrierPinIdsByChipId: Record<ChipId, PinId>
+    passiveChipIds: ChipId[]
+    side: Side
+    baseCarrierPlacement: Placement
+    outwardAxis: "x" | "y"
+    alignAxis: "x" | "y"
+  }): Placement | null {
+    const prob = this.partitionInputProblem
+    const carrierChip = prob.chipMap[carrierChipId]
+    if (!carrierChip) return null
+
+    const passiveBounds = getBoundsFromPoints(
+      passiveChipIds.flatMap((chipId) => {
+        const bounds = this.boxFor(chipId, candidatePlacements[chipId]!)
+        return [
+          { x: bounds.minX, y: bounds.minY },
+          { x: bounds.maxX, y: bounds.maxY },
+        ]
+      }),
+    )
+    if (!passiveBounds) return null
+
+    const rotations = carrierChip.availableRotations ?? [
+      baseCarrierPlacement.ccwRotationDegrees,
+    ]
+    let bestCandidate: { placement: Placement; score: number } | null = null
+
+    for (const ccwRotationDegrees of rotations) {
+      const offsets = passiveChipIds.map((passiveChipId) => {
+        const passivePinId = passiveCarrierPinIdsByChipId[passiveChipId]
+        const carrierPinId = carrierPinIdsByPassiveChipId[passiveChipId]
+        const passivePlacement = candidatePlacements[passiveChipId]
+        const passivePin = passivePinId && prob.chipPinMap[passivePinId]
+        const carrierPin = carrierPinId && prob.chipPinMap[carrierPinId]
+        if (!passivePlacement || !passivePin || !carrierPin) return null
+        const passivePinOffset = rotatePinOffset(
+          passivePin.offset,
+          passivePlacement.ccwRotationDegrees,
+        )
+        const carrierPinOffset = rotatePinOffset(
+          carrierPin.offset,
+          ccwRotationDegrees,
+        )
+        return {
+          passivePinPosition: {
+            x: passivePlacement.x + passivePinOffset.x,
+            y: passivePlacement.y + passivePinOffset.y,
+          },
+          carrierPinOffset,
+        }
+      })
+      if (offsets.some((offset) => offset === null)) continue
+
+      const alignCoordinate =
+        offsets.reduce(
+          (sum, offset) =>
+            sum +
+            offset!.passivePinPosition[alignAxis] -
+            offset!.carrierPinOffset[alignAxis],
+          0,
+        ) / offsets.length
+      const maxAlignmentError = Math.max(
+        ...offsets.map((offset) =>
+          Math.abs(
+            offset!.passivePinPosition[alignAxis] -
+              (alignCoordinate + offset!.carrierPinOffset[alignAxis]),
+          ),
+        ),
+      )
+
+      const carrierSize = getRotatedSize(carrierChip.size, ccwRotationDegrees)
+      const placement: Placement = {
+        x: baseCarrierPlacement.x,
+        y: baseCarrierPlacement.y,
+        ccwRotationDegrees,
+        [alignAxis]: alignCoordinate,
+      }
+      if (side === "x+") {
+        placement.x =
+          passiveBounds.maxX +
+          this.partitionInputProblem.chipGap +
+          carrierSize.x / 2
+      } else if (side === "x-") {
+        placement.x =
+          passiveBounds.minX -
+          this.partitionInputProblem.chipGap -
+          carrierSize.x / 2
+      } else if (side === "y+") {
+        placement.y =
+          passiveBounds.maxY +
+          this.partitionInputProblem.chipGap +
+          carrierSize.y / 2
+      } else {
+        placement.y =
+          passiveBounds.minY -
+          this.partitionInputProblem.chipGap -
+          carrierSize.y / 2
+      }
+
+      const outwardDistance = Math.abs(
+        placement[outwardAxis] - getBoundsCenter(passiveBounds)[outwardAxis],
+      )
+      const score = maxAlignmentError * 100 + outwardDistance
+      if (!bestCandidate || score < bestCandidate.score) {
+        bestCandidate = { placement, score }
+      }
+    }
+
+    return bestCandidate?.placement ?? null
+  }
+
+  private movePastEarlierGroupOverlaps({
+    candidatePlacements,
+    chipId,
+    previousChipIds,
+    outwardAxis,
+    outwardSign,
+  }: {
+    candidatePlacements: Record<ChipId, Placement>
+    chipId: ChipId
+    previousChipIds: ChipId[]
+    outwardAxis: "x" | "y"
+    outwardSign: number
+  }): void {
+    const placement = candidatePlacements[chipId]
+    if (!placement) return
+
+    for (const previousChipId of previousChipIds) {
+      const previousPlacement = candidatePlacements[previousChipId]
+      if (!previousPlacement) continue
+      const previousBounds = this.boxFor(previousChipId, previousPlacement)
+      let bounds = this.boxFor(chipId, placement)
+      if (!doBoundsOverlap(bounds, previousBounds)) continue
+
+      if (outwardAxis === "x" && outwardSign > 0) {
+        placement.x += previousBounds.maxX - bounds.minX + CLEARANCE_EPSILON
+      } else if (outwardAxis === "x") {
+        placement.x -= bounds.maxX - previousBounds.minX + CLEARANCE_EPSILON
+      } else if (outwardSign > 0) {
+        placement.y += previousBounds.maxY - bounds.minY + CLEARANCE_EPSILON
+      } else {
+        placement.y -= bounds.maxY - previousBounds.minY + CLEARANCE_EPSILON
+      }
+    }
+  }
+
+  private hasAnyOverlapAfterMove(
+    candidatePlacements: Record<ChipId, Placement>,
+    placements: Record<ChipId, Placement>,
+    movedChipIds: ChipId[],
+  ): boolean {
+    const movedChipIdSet = new Set(movedChipIds)
+    const nextPlacements = { ...placements, ...candidatePlacements }
+
+    for (let i = 0; i < movedChipIds.length; i++) {
+      const chipId = movedChipIds[i]!
+      const bounds = this.boxFor(chipId, nextPlacements[chipId]!)
+
+      for (let j = i + 1; j < movedChipIds.length; j++) {
+        const otherChipId = movedChipIds[j]!
+        const otherBounds = this.boxFor(
+          otherChipId,
+          nextPlacements[otherChipId]!,
+        )
+        if (doBoundsOverlap(bounds, otherBounds)) return true
+      }
+
+      for (const [otherChipId, otherPlacement] of Object.entries(placements)) {
+        if (movedChipIdSet.has(otherChipId)) continue
+        if (doBoundsOverlap(bounds, this.boxFor(otherChipId, otherPlacement))) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+
+  private pinPosition(
+    _chipId: ChipId,
+    pinId: PinId,
+    placement: Placement,
+  ): { x: number; y: number } | null {
+    const pin = this.partitionInputProblem.chipPinMap[pinId]
+    if (!pin) return null
+    const offset = rotatePinOffset(pin.offset, placement.ccwRotationDegrees)
+    return {
+      x: placement.x + offset.x,
+      y: placement.y + offset.y,
+    }
   }
 
   private reflowPassiveGroup(

--- a/lib/solvers/PackInnerPartitionsSolver/ParallelAlignedPassiveSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/ParallelAlignedPassiveSolver.ts
@@ -47,6 +47,12 @@ import { applyDirectPassiveTraceClearance } from "../../utils/offsetCollinearCon
 const CLEARANCE_EPSILON = 1e-6
 const MAX_RESOLVE_ITERATIONS = 16
 
+const signWithEpsilon = (value: number): -1 | 0 | 1 => {
+  if (value > CLEARANCE_EPSILON) return 1
+  if (value < -CLEARANCE_EPSILON) return -1
+  return 0
+}
+
 /** Outward unit vector (main-chip centre → edge) for each side. */
 const OUTWARD_BY_SIDE: Record<Side, { x: number; y: number }> = {
   "x-": { x: -1, y: 0 },
@@ -70,6 +76,12 @@ const edgeCoordForSide = (
 ): number => {
   if (side === "x-" || side === "x+") return offset.y
   return offset.x
+}
+
+type RailCarrierLayoutItem = {
+  chipId: ChipId
+  passiveCarrierPinId: PinId
+  carrierPinId: PinId
 }
 
 /** Gap between two bounds along a single axis (0 if they overlap on that axis). */
@@ -158,40 +170,59 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
     const gap = prob.chipGap
     const mainChipPlacement = placements[passiveGroup.mainChipId]
     const carrierPlacement = placements[railCarrier.carrierChipId]
-    const carrierChip = prob.chipMap[railCarrier.carrierChipId]
-    if (!mainChipPlacement || !carrierPlacement || !carrierChip) return
-    const physicalPassiveGroup = this.getPhysicalRailCarrierPassiveGroup(
-      passiveGroup,
-      mainChipPlacement,
-    )
-    if (!physicalPassiveGroup) return
-    passiveGroup = physicalPassiveGroup
+    if (!mainChipPlacement || !carrierPlacement) return
 
-    const outward = OUTWARD_BY_SIDE[passiveGroup.side]
+    const ordered = passiveGroup.passiveChipIds.map((chipId, index) => {
+      const mainPinId = passiveGroup.mainChipPinIds[index]
+      const mainPin = mainPinId && prob.chipPinMap[mainPinId]
+      const passiveMainPinId = railCarrier.passiveMainPinIds[index]
+      const passiveCarrierPinId = railCarrier.passiveCarrierPinIds[index]
+      const carrierPinId = railCarrier.carrierPinIds[index]
+      if (
+        !mainPinId ||
+        !mainPin ||
+        !passiveMainPinId ||
+        !passiveCarrierPinId ||
+        !carrierPinId
+      ) {
+        return null
+      }
+      const rotatedOffset = rotatePinOffset(
+        mainPin.offset,
+        mainChipPlacement.ccwRotationDegrees,
+      )
+      const side = sideForRotatedOffset(rotatedOffset)
+      return {
+        chipId,
+        mainPinId,
+        passiveMainPinId,
+        passiveCarrierPinId,
+        carrierPinId,
+        side,
+        edgeCoord: edgeCoordForSide(rotatedOffset, side),
+      }
+    })
+    if (ordered.length !== 2 || ordered.some((entry) => entry === null)) return
+    const side = ordered[0]!.side
+    if (ordered.some((entry) => entry!.side !== side)) return
+    ordered.sort((a, b) => a!.edgeCoord - b!.edgeCoord)
+
+    const outward = OUTWARD_BY_SIDE[side]
     const outwardAxis: "x" | "y" = outward.x === 0 ? "y" : "x"
     const alignAxis: "x" | "y" = outwardAxis === "x" ? "y" : "x"
     const mainChipBox = this.boxFor(passiveGroup.mainChipId, mainChipPlacement)
     const candidatePlacements: Record<ChipId, Placement> = {}
 
-    for (const [
-      index,
-      passiveChipId,
-    ] of passiveGroup.passiveChipIds.entries()) {
-      const passiveChip = prob.chipMap[passiveChipId]
-      const packedPlacement = placements[passiveChipId]
-      const mainPinId = passiveGroup.mainChipPinIds[index]
-      const passiveMainPinId =
-        railCarrier.passiveMainPinIdsByChipId[passiveChipId]
-      if (!passiveChip || !packedPlacement || !mainPinId || !passiveMainPinId) {
-        return
-      }
-
+    for (const [index, item] of ordered.entries()) {
+      const passiveChip = prob.chipMap[item!.chipId]
+      const packedPlacement = placements[item!.chipId]
+      if (!passiveChip || !packedPlacement) return
       const mainPinPosition = this.pinPosition(
         passiveGroup.mainChipId,
-        mainPinId,
+        item!.mainPinId,
         mainChipPlacement,
       )
-      const passiveMainPin = prob.chipPinMap[passiveMainPinId]
+      const passiveMainPin = prob.chipPinMap[item!.passiveMainPinId]
       if (!mainPinPosition || !passiveMainPin) return
 
       const passiveSize = getRotatedSize(
@@ -207,152 +238,125 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
         [alignAxis]:
           mainPinPosition[alignAxis] - passiveMainPinOffset[alignAxis],
       }
-      if (passiveGroup.side === "x+") {
+      if (side === "x+") {
         nextPlacement.x = mainChipBox.maxX + gap + passiveSize.x / 2
-      } else if (passiveGroup.side === "x-") {
+      } else if (side === "x-") {
         nextPlacement.x = mainChipBox.minX - gap - passiveSize.x / 2
-      } else if (passiveGroup.side === "y+") {
+      } else if (side === "y+") {
         nextPlacement.y = mainChipBox.maxY + gap + passiveSize.y / 2
       } else {
         nextPlacement.y = mainChipBox.minY - gap - passiveSize.y / 2
       }
-      candidatePlacements[passiveChipId] = nextPlacement
-      this.movePastEarlierGroupOverlaps({
-        candidatePlacements,
-        chipId: passiveChipId,
-        previousChipIds: passiveGroup.passiveChipIds.slice(0, index),
-        outwardAxis,
-        outwardSign: outward[outwardAxis],
-        gap,
-      })
+      candidatePlacements[item!.chipId] = nextPlacement
+      if (index === 1) {
+        const previousChipId = ordered[0]!.chipId
+        const previousBounds = this.boxFor(
+          previousChipId,
+          candidatePlacements[previousChipId]!,
+        )
+        const bounds = this.boxFor(item!.chipId, nextPlacement)
+        if (boundsDistance(bounds, previousBounds) < gap - CLEARANCE_EPSILON) {
+          const crossGap = axisGap(bounds, previousBounds, alignAxis)
+          const neededGap = Math.sqrt(
+            Math.max(0, gap * gap - crossGap * crossGap),
+          )
+          let adjustment: number
+          if (outwardAxis === "x" && outward.x > 0) {
+            adjustment = previousBounds.maxX - bounds.minX + neededGap
+          } else if (outwardAxis === "x") {
+            adjustment = bounds.maxX - previousBounds.minX + neededGap
+          } else if (outward.y > 0) {
+            adjustment = previousBounds.maxY - bounds.minY + neededGap
+          } else {
+            adjustment = bounds.maxY - previousBounds.minY + neededGap
+          }
+          nextPlacement[outwardAxis] +=
+            outward[outwardAxis] * (adjustment + CLEARANCE_EPSILON)
+        }
+      }
     }
 
-    const carrierCandidates = this.getRailCarrierPlacementCandidates({
+    const carrierCandidate = this.getUniqueRailCarrierPlacement({
       candidatePlacements,
       carrierChipId: railCarrier.carrierChipId,
-      carrierPinIdsByPassiveChipId: railCarrier.carrierPinIdsByPassiveChipId,
-      passiveCarrierPinIdsByChipId: railCarrier.passiveCarrierPinIdsByChipId,
-      passiveChipIds: passiveGroup.passiveChipIds,
-      side: passiveGroup.side,
+      items: ordered as RailCarrierLayoutItem[],
+      side,
       baseCarrierPlacement: carrierPlacement,
-      outwardAxis,
       alignAxis,
     })
-    if (carrierCandidates.length === 0) return
+    if (!carrierCandidate) return
 
     const movedChipIds = [
-      ...passiveGroup.passiveChipIds,
+      ...ordered.map((item) => item!.chipId),
       railCarrier.carrierChipId,
     ]
-
-    for (const carrierCandidate of carrierCandidates) {
-      const completeCandidatePlacements = {
-        ...candidatePlacements,
-        [railCarrier.carrierChipId]: carrierCandidate,
-      }
-      if (
-        this.hasChipGapViolationAfterMove(
-          completeCandidatePlacements,
-          placements,
-          movedChipIds,
-          gap,
-        )
-      ) {
-        continue
-      }
-
-      for (const chipId of movedChipIds) {
-        placements[chipId] = completeCandidatePlacements[chipId]!
-      }
+    const completeCandidatePlacements = {
+      ...candidatePlacements,
+      [railCarrier.carrierChipId]: carrierCandidate,
+    }
+    if (
+      this.hasChipGapViolationAfterMove(
+        completeCandidatePlacements,
+        placements,
+        movedChipIds,
+        gap,
+      )
+    ) {
       return
     }
-  }
 
-  private getPhysicalRailCarrierPassiveGroup(
-    passiveGroup: SameSidePassiveGroup,
-    mainChipPlacement: Placement,
-  ): SameSidePassiveGroup | null {
-    const prob = this.partitionInputProblem
-    const ordered = passiveGroup.passiveChipIds.map((passiveChipId, index) => {
-      const mainChipPinId = passiveGroup.mainChipPinIds[index]
-      const mainChipPin = mainChipPinId && prob.chipPinMap[mainChipPinId]
-      if (!mainChipPinId || !mainChipPin) return null
-      const rotatedOffset = rotatePinOffset(
-        mainChipPin.offset,
-        mainChipPlacement.ccwRotationDegrees,
-      )
-      const side = sideForRotatedOffset(rotatedOffset)
-      return {
-        passiveChipId,
-        mainChipPinId,
-        side,
-        edgeCoord: edgeCoordForSide(rotatedOffset, side),
-      }
-    })
-    if (ordered.some((entry) => entry === null)) return null
-
-    const firstEntry = ordered[0]
-    if (!firstEntry) return null
-    const side = firstEntry.side
-    if (ordered.some((entry) => entry!.side !== side)) return null
-
-    ordered.sort((a, b) => a!.edgeCoord - b!.edgeCoord)
-    return {
-      ...passiveGroup,
-      side,
-      passiveChipIds: ordered.map((entry) => entry!.passiveChipId),
-      mainChipPinIds: ordered.map((entry) => entry!.mainChipPinId),
+    for (const chipId of movedChipIds) {
+      placements[chipId] = completeCandidatePlacements[chipId]!
     }
   }
 
-  private getRailCarrierPlacementCandidates({
+  private getUniqueRailCarrierPlacement({
     candidatePlacements,
     carrierChipId,
-    carrierPinIdsByPassiveChipId,
-    passiveCarrierPinIdsByChipId,
-    passiveChipIds,
+    items,
     side,
     baseCarrierPlacement,
-    outwardAxis,
     alignAxis,
   }: {
     candidatePlacements: Record<ChipId, Placement>
     carrierChipId: ChipId
-    carrierPinIdsByPassiveChipId: Record<ChipId, PinId>
-    passiveCarrierPinIdsByChipId: Record<ChipId, PinId>
-    passiveChipIds: ChipId[]
+    items: RailCarrierLayoutItem[]
     side: Side
     baseCarrierPlacement: Placement
-    outwardAxis: "x" | "y"
     alignAxis: "x" | "y"
-  }): Placement[] {
+  }): Placement | null {
     const prob = this.partitionInputProblem
     const carrierChip = prob.chipMap[carrierChipId]
-    if (!carrierChip) return []
+    if (!carrierChip || items.length !== 2) return null
 
     const passiveBounds = getBoundsFromPoints(
-      passiveChipIds.flatMap((chipId) => {
-        const bounds = this.boxFor(chipId, candidatePlacements[chipId]!)
+      items.flatMap((item) => {
+        const bounds = this.boxFor(
+          item.chipId,
+          candidatePlacements[item.chipId]!,
+        )
         return [
           { x: bounds.minX, y: bounds.minY },
           { x: bounds.maxX, y: bounds.maxY },
         ]
       }),
     )
-    if (!passiveBounds) return []
+    if (!passiveBounds) return null
 
-    const rotations = carrierChip.availableRotations ?? [
-      baseCarrierPlacement.ccwRotationDegrees,
+    const rotations = [
+      ...new Set(
+        carrierChip.availableRotations ?? [
+          baseCarrierPlacement.ccwRotationDegrees,
+        ],
+      ),
     ]
-    const candidates: Array<{ placement: Placement; score: number }> = []
+    const compatiblePlacements: Placement[] = []
 
     for (const ccwRotationDegrees of rotations) {
-      const offsets = passiveChipIds.map((passiveChipId) => {
-        const passivePinId = passiveCarrierPinIdsByChipId[passiveChipId]
-        const carrierPinId = carrierPinIdsByPassiveChipId[passiveChipId]
-        const passivePlacement = candidatePlacements[passiveChipId]
-        const passivePin = passivePinId && prob.chipPinMap[passivePinId]
-        const carrierPin = carrierPinId && prob.chipPinMap[carrierPinId]
+      const offsets = items.map((item) => {
+        const passivePlacement = candidatePlacements[item.chipId]
+        const passivePin = prob.chipPinMap[item.passiveCarrierPinId]
+        const carrierPin = prob.chipPinMap[item.carrierPinId]
         if (!passivePlacement || !passivePin || !carrierPin) return null
         const passivePinOffset = rotatePinOffset(
           passivePin.offset,
@@ -371,6 +375,19 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
         }
       })
       if (offsets.some((offset) => offset === null)) continue
+      const firstOffset = offsets[0]!
+      const secondOffset = offsets[1]!
+      const passiveDirection = signWithEpsilon(
+        secondOffset.passivePinPosition[alignAxis] -
+          firstOffset.passivePinPosition[alignAxis],
+      )
+      const carrierDirection = signWithEpsilon(
+        secondOffset.carrierPinOffset[alignAxis] -
+          firstOffset.carrierPinOffset[alignAxis],
+      )
+      if (passiveDirection === 0 || passiveDirection !== carrierDirection) {
+        continue
+      }
 
       const alignCoordinate =
         offsets.reduce(
@@ -380,14 +397,6 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
             offset!.carrierPinOffset[alignAxis],
           0,
         ) / offsets.length
-      const maxAlignmentError = Math.max(
-        ...offsets.map((offset) =>
-          Math.abs(
-            offset!.passivePinPosition[alignAxis] -
-              (alignCoordinate + offset!.carrierPinOffset[alignAxis]),
-          ),
-        ),
-      )
 
       const carrierSize = getRotatedSize(carrierChip.size, ccwRotationDegrees)
       const placement: Placement = {
@@ -418,73 +427,10 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
           carrierSize.y / 2
       }
 
-      const outwardDistance = Math.abs(
-        placement[outwardAxis] - getBoundsCenter(passiveBounds)[outwardAxis],
-      )
-      const score = maxAlignmentError * 100 + outwardDistance
-      candidates.push({ placement, score })
+      compatiblePlacements.push(placement)
     }
 
-    candidates.sort((a, b) => {
-      const scoreDelta = a.score - b.score
-      if (scoreDelta !== 0) return scoreDelta
-      return a.placement.ccwRotationDegrees - b.placement.ccwRotationDegrees
-    })
-
-    return candidates.map((candidate) => candidate.placement)
-  }
-
-  private movePastEarlierGroupOverlaps({
-    candidatePlacements,
-    chipId,
-    previousChipIds,
-    outwardAxis,
-    outwardSign,
-    gap,
-  }: {
-    candidatePlacements: Record<ChipId, Placement>
-    chipId: ChipId
-    previousChipIds: ChipId[]
-    outwardAxis: "x" | "y"
-    outwardSign: number
-    gap: number
-  }): void {
-    const placement = candidatePlacements[chipId]
-    if (!placement) return
-
-    for (const previousChipId of previousChipIds) {
-      const previousPlacement = candidatePlacements[previousChipId]
-      if (!previousPlacement) continue
-      const previousBounds = this.boxFor(previousChipId, previousPlacement)
-      let bounds = this.boxFor(chipId, placement)
-      if (boundsDistance(bounds, previousBounds) >= gap - CLEARANCE_EPSILON) {
-        continue
-      }
-
-      const crossAxis: "x" | "y" = outwardAxis === "x" ? "y" : "x"
-      const crossGap = axisGap(bounds, previousBounds, crossAxis)
-      const neededOutwardGap = Math.sqrt(
-        Math.max(0, gap * gap - crossGap * crossGap),
-      )
-      let adjustment: number
-      if (outwardAxis === "x" && outwardSign > 0) {
-        adjustment = previousBounds.maxX - bounds.minX + neededOutwardGap
-      } else if (outwardAxis === "x") {
-        adjustment = bounds.maxX - previousBounds.minX + neededOutwardGap
-      } else if (outwardSign > 0) {
-        adjustment = previousBounds.maxY - bounds.minY + neededOutwardGap
-      } else {
-        adjustment = bounds.maxY - previousBounds.minY + neededOutwardGap
-      }
-      adjustment += CLEARANCE_EPSILON
-      if (adjustment <= CLEARANCE_EPSILON) continue
-
-      if (outwardAxis === "x") {
-        placement.x += outwardSign * adjustment
-      } else {
-        placement.y += outwardSign * adjustment
-      }
-    }
+    return compatiblePlacements.length === 1 ? compatiblePlacements[0]! : null
   }
 
   private hasChipGapViolationAfterMove(

--- a/lib/solvers/PackInnerPartitionsSolver/ParallelAlignedPassiveSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/ParallelAlignedPassiveSolver.ts
@@ -246,7 +246,12 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
       railCarrier.carrierChipId,
     ]
     if (
-      this.hasAnyOverlapAfterMove(candidatePlacements, placements, movedChipIds)
+      this.hasChipGapViolationAfterMove(
+        candidatePlacements,
+        placements,
+        movedChipIds,
+        gap,
+      )
     ) {
       return
     }
@@ -471,30 +476,25 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
     }
   }
 
-  private hasAnyOverlapAfterMove(
+  private hasChipGapViolationAfterMove(
     candidatePlacements: Record<ChipId, Placement>,
     placements: Record<ChipId, Placement>,
     movedChipIds: ChipId[],
+    gap: number,
   ): boolean {
-    const movedChipIdSet = new Set(movedChipIds)
     const nextPlacements = { ...placements, ...candidatePlacements }
 
     for (let i = 0; i < movedChipIds.length; i++) {
       const chipId = movedChipIds[i]!
       const bounds = this.boxFor(chipId, nextPlacements[chipId]!)
 
-      for (let j = i + 1; j < movedChipIds.length; j++) {
-        const otherChipId = movedChipIds[j]!
-        const otherBounds = this.boxFor(
-          otherChipId,
-          nextPlacements[otherChipId]!,
-        )
+      for (const [otherChipId, otherPlacement] of Object.entries(
+        nextPlacements,
+      )) {
+        if (otherChipId === chipId) continue
+        const otherBounds = this.boxFor(otherChipId, otherPlacement)
         if (doBoundsOverlap(bounds, otherBounds)) return true
-      }
-
-      for (const [otherChipId, otherPlacement] of Object.entries(placements)) {
-        if (movedChipIdSet.has(otherChipId)) continue
-        if (doBoundsOverlap(bounds, this.boxFor(otherChipId, otherPlacement))) {
+        if (boundsDistance(bounds, otherBounds) < gap - CLEARANCE_EPSILON) {
           return true
         }
       }

--- a/lib/solvers/PackInnerPartitionsSolver/ParallelAlignedPassiveSolver.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/ParallelAlignedPassiveSolver.ts
@@ -55,6 +55,23 @@ const OUTWARD_BY_SIDE: Record<Side, { x: number; y: number }> = {
   "y+": { x: 0, y: 1 },
 }
 
+const sideForRotatedOffset = (offset: { x: number; y: number }): Side => {
+  if (Math.abs(offset.x) >= Math.abs(offset.y)) {
+    if (offset.x >= 0) return "x+"
+    return "x-"
+  }
+  if (offset.y >= 0) return "y+"
+  return "y-"
+}
+
+const edgeCoordForSide = (
+  offset: { x: number; y: number },
+  side: Side,
+): number => {
+  if (side === "x-" || side === "x+") return offset.y
+  return offset.x
+}
+
 /** Gap between two bounds along a single axis (0 if they overlap on that axis). */
 const axisGap = (a: Bounds, b: Bounds, axis: "x" | "y"): number => {
   if (axis === "x") return Math.max(0, a.minX - b.maxX, b.minX - a.maxX)
@@ -143,6 +160,12 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
     const carrierPlacement = placements[railCarrier.carrierChipId]
     const carrierChip = prob.chipMap[railCarrier.carrierChipId]
     if (!mainChipPlacement || !carrierPlacement || !carrierChip) return
+    const physicalPassiveGroup = this.getPhysicalRailCarrierPassiveGroup(
+      passiveGroup,
+      mainChipPlacement,
+    )
+    if (!physicalPassiveGroup) return
+    passiveGroup = physicalPassiveGroup
 
     const outward = OUTWARD_BY_SIDE[passiveGroup.side]
     const outwardAxis: "x" | "y" = outward.x === 0 ? "y" : "x"
@@ -200,6 +223,7 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
         previousChipIds: passiveGroup.passiveChipIds.slice(0, index),
         outwardAxis,
         outwardSign: outward[outwardAxis],
+        gap,
       })
     }
 
@@ -229,6 +253,43 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
 
     for (const chipId of movedChipIds) {
       placements[chipId] = candidatePlacements[chipId]!
+    }
+  }
+
+  private getPhysicalRailCarrierPassiveGroup(
+    passiveGroup: SameSidePassiveGroup,
+    mainChipPlacement: Placement,
+  ): SameSidePassiveGroup | null {
+    const prob = this.partitionInputProblem
+    const ordered = passiveGroup.passiveChipIds.map((passiveChipId, index) => {
+      const mainChipPinId = passiveGroup.mainChipPinIds[index]
+      const mainChipPin = mainChipPinId && prob.chipPinMap[mainChipPinId]
+      if (!mainChipPinId || !mainChipPin) return null
+      const rotatedOffset = rotatePinOffset(
+        mainChipPin.offset,
+        mainChipPlacement.ccwRotationDegrees,
+      )
+      const side = sideForRotatedOffset(rotatedOffset)
+      return {
+        passiveChipId,
+        mainChipPinId,
+        side,
+        edgeCoord: edgeCoordForSide(rotatedOffset, side),
+      }
+    })
+    if (ordered.some((entry) => entry === null)) return null
+
+    const firstEntry = ordered[0]
+    if (!firstEntry) return null
+    const side = firstEntry.side
+    if (ordered.some((entry) => entry!.side !== side)) return null
+
+    ordered.sort((a, b) => a!.edgeCoord - b!.edgeCoord)
+    return {
+      ...passiveGroup,
+      side,
+      passiveChipIds: ordered.map((entry) => entry!.passiveChipId),
+      mainChipPinIds: ordered.map((entry) => entry!.mainChipPinId),
     }
   }
 
@@ -363,12 +424,14 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
     previousChipIds,
     outwardAxis,
     outwardSign,
+    gap,
   }: {
     candidatePlacements: Record<ChipId, Placement>
     chipId: ChipId
     previousChipIds: ChipId[]
     outwardAxis: "x" | "y"
     outwardSign: number
+    gap: number
   }): void {
     const placement = candidatePlacements[chipId]
     if (!placement) return
@@ -378,16 +441,32 @@ export class ParallelAlignedPassiveSolver extends BaseSolver {
       if (!previousPlacement) continue
       const previousBounds = this.boxFor(previousChipId, previousPlacement)
       let bounds = this.boxFor(chipId, placement)
-      if (!doBoundsOverlap(bounds, previousBounds)) continue
+      if (boundsDistance(bounds, previousBounds) >= gap - CLEARANCE_EPSILON) {
+        continue
+      }
 
+      const crossAxis: "x" | "y" = outwardAxis === "x" ? "y" : "x"
+      const crossGap = axisGap(bounds, previousBounds, crossAxis)
+      const neededOutwardGap = Math.sqrt(
+        Math.max(0, gap * gap - crossGap * crossGap),
+      )
+      let adjustment: number
       if (outwardAxis === "x" && outwardSign > 0) {
-        placement.x += previousBounds.maxX - bounds.minX + CLEARANCE_EPSILON
+        adjustment = previousBounds.maxX - bounds.minX + neededOutwardGap
       } else if (outwardAxis === "x") {
-        placement.x -= bounds.maxX - previousBounds.minX + CLEARANCE_EPSILON
+        adjustment = bounds.maxX - previousBounds.minX + neededOutwardGap
       } else if (outwardSign > 0) {
-        placement.y += previousBounds.maxY - bounds.minY + CLEARANCE_EPSILON
+        adjustment = previousBounds.maxY - bounds.minY + neededOutwardGap
       } else {
-        placement.y -= bounds.maxY - previousBounds.minY + CLEARANCE_EPSILON
+        adjustment = bounds.maxY - previousBounds.minY + neededOutwardGap
+      }
+      adjustment += CLEARANCE_EPSILON
+      if (adjustment <= CLEARANCE_EPSILON) continue
+
+      if (outwardAxis === "x") {
+        placement.x += outwardSign * adjustment
+      } else {
+        placement.y += outwardSign * adjustment
       }
     }
   }

--- a/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
@@ -17,13 +17,7 @@
  * layout and re-flows just the group into a clean row.
  */
 
-import type {
-  Chip,
-  ChipId,
-  InputProblem,
-  NetId,
-  PinId,
-} from "lib/types/InputProblem"
+import type { ChipId, InputProblem, NetId, PinId } from "lib/types/InputProblem"
 import type { Side } from "lib/types/Side"
 import { rotatePinOffset } from "lib/utils/rotatePinOffset"
 
@@ -41,10 +35,9 @@ export interface SameSidePassiveGroup {
   mainChipPinIds: PinId[]
   railCarrier?: {
     carrierChipId: ChipId
-    railPinId: PinId
-    passiveMainPinIdsByChipId: Record<ChipId, PinId>
-    passiveCarrierPinIdsByChipId: Record<ChipId, PinId>
-    carrierPinIdsByPassiveChipId: Record<ChipId, PinId>
+    passiveMainPinIds: PinId[]
+    passiveCarrierPinIds: PinId[]
+    carrierPinIds: PinId[]
   }
 }
 
@@ -115,12 +108,6 @@ const edgeCoordForSide = (
   return offset.x
 }
 
-const isRailCarrierPassiveLeaf = (chip: Chip): boolean =>
-  chip.pins.length === PASSIVE_PIN_COUNT && chip.isResistor === true
-
-const passiveSetKey = (passiveChipIds: ChipId[]): string =>
-  [...passiveChipIds].sort().join("|")
-
 type StrongConnection = {
   selfPin: PinId
   otherPin: PinId
@@ -139,140 +126,13 @@ interface RailCarrierCandidate {
   carrierChipId: ChipId
 }
 
-const hasOnlyExpectedStrongConnection = (
-  strongs: StrongConnection[],
-  selfPin: PinId,
-  expectedOtherPin: PinId,
-  expectedOtherChip: ChipId,
-): boolean => {
-  const matchingSelfPinConnections = strongs.filter(
-    (strong) => strong.selfPin === selfPin,
-  )
-  if (matchingSelfPinConnections.length !== 1) return false
-  const connection = matchingSelfPinConnections[0]!
-  return (
-    connection.otherPin === expectedOtherPin &&
-    connection.otherChip === expectedOtherChip
-  )
-}
-
-const hasUniqueValues = (values: string[]): boolean =>
+const hasDistinctValues = (values: string[]): boolean =>
   new Set(values).size === values.length
 
 const sortRailCarrierCandidates = (
   candidates: RailCarrierCandidate[],
 ): void => {
-  candidates.sort((a, b) => {
-    if (a.edgeCoord !== b.edgeCoord) return a.edgeCoord - b.edgeCoord
-    return (
-      a.mainChipPinId.localeCompare(b.mainChipPinId) ||
-      a.passiveChipId.localeCompare(b.passiveChipId) ||
-      a.carrierPinId.localeCompare(b.carrierPinId)
-    )
-  })
-}
-
-const buildRailCarrierGroupIfValid = ({
-  problem,
-  candidates,
-  strongByChip,
-}: {
-  problem: InputProblem
-  candidates: RailCarrierCandidate[]
-  strongByChip: Map<ChipId, StrongConnection[]>
-}): SameSidePassiveGroup | null => {
-  if (candidates.length < MIN_COMMON_NODE_PASSIVE_GROUP_SIZE) return null
-  const firstCandidate = candidates[0]
-  if (!firstCandidate) return null
-
-  const { mainChipId, side, carrierChipId } = firstCandidate
-  if (
-    candidates.some(
-      (candidate) =>
-        candidate.mainChipId !== mainChipId ||
-        candidate.side !== side ||
-        candidate.carrierChipId !== carrierChipId,
-    )
-  ) {
-    return null
-  }
-
-  const carrierChip = problem.chipMap[carrierChipId]
-  if (!carrierChip) return null
-
-  const passiveChipIds = candidates.map((candidate) => candidate.passiveChipId)
-  if (!hasUniqueValues(passiveChipIds)) return null
-
-  const mainChipPinIds = candidates.map((candidate) => candidate.mainChipPinId)
-  if (!hasUniqueValues(mainChipPinIds)) return null
-
-  const edgeCoords = candidates.map((candidate) => `${candidate.edgeCoord}`)
-  if (!hasUniqueValues(edgeCoords)) return null
-
-  const carrierPinIds = candidates.map((candidate) => candidate.carrierPinId)
-  if (!hasUniqueValues(carrierPinIds)) return null
-
-  const claimedCarrierPins = new Set(carrierPinIds)
-  for (const carrierPinId of carrierChip.pins) {
-    const carrierPinStrongConnections = (
-      strongByChip.get(carrierChipId) ?? []
-    ).filter((strong) => strong.selfPin === carrierPinId)
-    if (claimedCarrierPins.has(carrierPinId)) {
-      const matchingPassiveConnections = carrierPinStrongConnections.filter(
-        (strong) => passiveChipIds.includes(strong.otherChip),
-      )
-      if (
-        matchingPassiveConnections.length !== 1 ||
-        carrierPinStrongConnections.length !== 1
-      ) {
-        return null
-      }
-      continue
-    }
-    if (carrierPinStrongConnections.length > 0) return null
-  }
-
-  const railPins = carrierChip.pins.filter(
-    (pinId) =>
-      !claimedCarrierPins.has(pinId) &&
-      getNetIdsForPin(problem, pinId).length === 1,
-  )
-  if (railPins.length !== 1) return null
-
-  const accountedCarrierPins = new Set([...carrierPinIds, railPins[0]!])
-  if (carrierChip.pins.some((pinId) => !accountedCarrierPins.has(pinId))) {
-    return null
-  }
-
-  sortRailCarrierCandidates(candidates)
-  return {
-    mainChipId,
-    side,
-    passiveChipIds: candidates.map((candidate) => candidate.passiveChipId),
-    mainChipPinIds: candidates.map((candidate) => candidate.mainChipPinId),
-    railCarrier: {
-      carrierChipId,
-      railPinId: railPins[0]!,
-      passiveMainPinIdsByChipId: Object.fromEntries(
-        candidates.map((candidate) => [
-          candidate.passiveChipId,
-          candidate.passiveMainPinId,
-        ]),
-      ),
-      passiveCarrierPinIdsByChipId: Object.fromEntries(
-        candidates.map((candidate) => [
-          candidate.passiveChipId,
-          candidate.passiveCarrierPinId,
-        ]),
-      ),
-      carrierPinIdsByPassiveChipId: Object.fromEntries(
-        candidates.map((candidate) => [
-          candidate.passiveChipId,
-          candidate.carrierPinId,
-        ]),
-      ),
-    },
-  }
+  candidates.sort((a, b) => a.edgeCoord - b.edgeCoord)
 }
 
 /**
@@ -303,116 +163,110 @@ export const findSameSidePassiveGroups = (
 
   for (const [passiveChipId, passiveChip] of Object.entries(problem.chipMap)) {
     if (passiveChip.fixedPosition) continue
-    if (!isRailCarrierPassiveLeaf(passiveChip)) continue
+    if (passiveChip.pins.length !== PASSIVE_PIN_COUNT) continue
+    if (passiveChip.isResistor !== true) continue
 
     const strongs = strongByChip.get(passiveChipId) ?? []
-    for (const strongToMain of strongs) {
-      const mainChipId = strongToMain.otherChip
-      const mainChip = problem.chipMap[mainChipId]
-      const mainPin = problem.chipPinMap[strongToMain.otherPin]
-      if (!mainChip || !mainPin) continue
-      if (mainChip.pins.length < MAIN_CHIP_MIN_PINS) continue
-      if (
-        !hasOnlyExpectedStrongConnection(
-          strongs,
-          strongToMain.selfPin,
-          strongToMain.otherPin,
-          mainChipId,
-        )
-      ) {
-        continue
-      }
-
-      const passiveCarrierPinId = passiveChip.pins.find(
-        (pinId) => pinId !== strongToMain.selfPin,
+    if (strongs.length !== 2) continue
+    const mainStrong = strongs.find((strong) => {
+      const chip = problem.chipMap[strong.otherChip]
+      return (
+        chip && !chip.fixedPosition && chip.pins.length >= MAIN_CHIP_MIN_PINS
       )
-      if (!passiveCarrierPinId) continue
+    })
+    const carrierStrong = strongs.find((strong) => {
+      const chip = problem.chipMap[strong.otherChip]
+      return chip && !chip.fixedPosition && chip.pins.length === 3
+    })
+    if (!mainStrong || !carrierStrong) continue
+    if (mainStrong.selfPin === carrierStrong.selfPin) continue
+    if (mainStrong.otherChip === carrierStrong.otherChip) continue
 
-      const carrierStrongConnections = strongs.filter(
-        (strong) => strong.selfPin === passiveCarrierPinId,
-      )
-      if (carrierStrongConnections.length !== 1) continue
-
-      const carrierConnection = carrierStrongConnections[0]!
-      const carrierChipId = carrierConnection.otherChip
-      if (carrierChipId === mainChipId) continue
-      if (
-        !hasOnlyExpectedStrongConnection(
-          strongs,
-          passiveCarrierPinId,
-          carrierConnection.otherPin,
-          carrierChipId,
-        )
-      ) {
-        continue
-      }
-      const carrierChip = problem.chipMap[carrierChipId]
-      if (!carrierChip || carrierChip.fixedPosition) continue
-      if (carrierChip.pins.length < MIN_COMMON_NODE_PASSIVE_GROUP_SIZE + 1)
-        continue
-
-      const mainChipRotation = mainChip.availableRotations?.[0] ?? 0
-      const mainChipPinOffset = rotatePinOffset(
-        mainPin.offset,
-        mainChipRotation,
-      )
-      const side = getMainChipPinSide(mainPin.offset, mainChipRotation)
-      const key = `${mainChipId}|${side}|${carrierChipId}`
-      const candidates = railCarrierCandidatesByGroup.get(key) ?? []
-      candidates.push({
+    const mainPin = problem.chipPinMap[mainStrong.otherPin]
+    const mainChip = problem.chipMap[mainStrong.otherChip]!
+    if (!mainPin) continue
+    const mainChipRotation = mainChip.availableRotations?.[0] ?? 0
+    const mainChipPinOffset = rotatePinOffset(mainPin.offset, mainChipRotation)
+    const side = getMainChipPinSide(mainPin.offset, mainChipRotation)
+    const key = `${mainStrong.otherChip}|${side}|${carrierStrong.otherChip}`
+    railCarrierCandidatesByGroup.set(key, [
+      ...(railCarrierCandidatesByGroup.get(key) ?? []),
+      {
         passiveChipId,
-        passiveMainPinId: strongToMain.selfPin,
-        passiveCarrierPinId,
-        carrierPinId: carrierConnection.otherPin,
-        mainChipPinId: strongToMain.otherPin,
+        passiveMainPinId: mainStrong.selfPin,
+        passiveCarrierPinId: carrierStrong.selfPin,
+        carrierPinId: carrierStrong.otherPin,
+        mainChipPinId: mainStrong.otherPin,
         edgeCoord: edgeCoordForSide(mainChipPinOffset, side),
-        mainChipId,
+        mainChipId: mainStrong.otherChip,
         side,
-        carrierChipId,
-      })
-      railCarrierCandidatesByGroup.set(key, candidates)
-    }
+        carrierChipId: carrierStrong.otherChip,
+      },
+    ])
   }
 
   for (const candidates of railCarrierCandidatesByGroup.values()) {
-    const group = buildRailCarrierGroupIfValid({
-      problem,
-      candidates,
-      strongByChip,
-    })
-    if (group) railCarrierGroups.push(group)
-  }
+    const first = candidates[0]
+    if (!first || candidates.length !== 2) continue
+    const carrierChip = problem.chipMap[first.carrierChipId]
+    if (!carrierChip || carrierChip.pins.length !== 3) continue
 
-  const ambiguousRailCarrierGroupKeys = new Set<string>()
-  for (let i = 0; i < railCarrierGroups.length; i++) {
-    const group = railCarrierGroups[i]!
-    if (!group.railCarrier) continue
-    const groupPassiveKey = passiveSetKey(group.passiveChipIds)
-    for (let j = i + 1; j < railCarrierGroups.length; j++) {
-      const otherGroup = railCarrierGroups[j]!
-      const otherRailCarrier = otherGroup.railCarrier
-      if (!otherRailCarrier) continue
-      if (
-        group.mainChipId === otherRailCarrier.carrierChipId &&
-        group.railCarrier.carrierChipId === otherGroup.mainChipId &&
-        groupPassiveKey === passiveSetKey(otherGroup.passiveChipIds)
-      ) {
-        ambiguousRailCarrierGroupKeys.add(
-          `${group.mainChipId}|${group.railCarrier.carrierChipId}|${groupPassiveKey}`,
-        )
-        ambiguousRailCarrierGroupKeys.add(
-          `${otherGroup.mainChipId}|${otherRailCarrier.carrierChipId}|${groupPassiveKey}`,
-        )
-      }
-    }
-  }
-  const unambiguousRailCarrierGroups = railCarrierGroups.filter((group) => {
-    const railCarrier = group.railCarrier
-    if (!railCarrier) return true
-    return !ambiguousRailCarrierGroupKeys.has(
-      `${group.mainChipId}|${railCarrier.carrierChipId}|${passiveSetKey(group.passiveChipIds)}`,
+    const passiveChipIds = candidates.map(
+      (candidate) => candidate.passiveChipId,
     )
-  })
+    const mainChipPinIds = candidates.map(
+      (candidate) => candidate.mainChipPinId,
+    )
+    const carrierPinIds = candidates.map((candidate) => candidate.carrierPinId)
+    if (
+      !hasDistinctValues(passiveChipIds) ||
+      !hasDistinctValues(mainChipPinIds) ||
+      !hasDistinctValues(carrierPinIds) ||
+      !hasDistinctValues(
+        candidates.map((candidate) => `${candidate.edgeCoord}`),
+      )
+    ) {
+      continue
+    }
+
+    const claimedCarrierPins = new Set(carrierPinIds)
+    const carrierPinsAreExclusive = carrierPinIds.every((carrierPinId) => {
+      const strongsForPin = (
+        strongByChip.get(first.carrierChipId) ?? []
+      ).filter((strong) => strong.selfPin === carrierPinId)
+      return (
+        strongsForPin.length === 1 &&
+        passiveChipIds.includes(strongsForPin[0]!.otherChip)
+      )
+    })
+    const railPins = carrierChip.pins.filter(
+      (pinId) =>
+        !claimedCarrierPins.has(pinId) &&
+        (strongByChip.get(first.carrierChipId) ?? []).every(
+          (strong) => strong.selfPin !== pinId,
+        ) &&
+        getNetIdsForPin(problem, pinId).length === 1,
+    )
+    if (!carrierPinsAreExclusive || railPins.length !== 1) continue
+
+    sortRailCarrierCandidates(candidates)
+    railCarrierGroups.push({
+      mainChipId: first.mainChipId,
+      side: first.side,
+      passiveChipIds: candidates.map((candidate) => candidate.passiveChipId),
+      mainChipPinIds: candidates.map((candidate) => candidate.mainChipPinId),
+      railCarrier: {
+        carrierChipId: first.carrierChipId,
+        passiveMainPinIds: candidates.map(
+          (candidate) => candidate.passiveMainPinId,
+        ),
+        passiveCarrierPinIds: candidates.map(
+          (candidate) => candidate.passiveCarrierPinId,
+        ),
+        carrierPinIds,
+      },
+    })
+  }
 
   const commonNodeGroups: SameSidePassiveGroup[] = []
   for (const strongs of strongByChip.values()) {
@@ -473,7 +327,7 @@ export const findSameSidePassiveGroups = (
     commonNodeGroups.flatMap((group) => group.passiveChipIds),
   )
   const railCarrierPassiveChipIds = new Set(
-    unambiguousRailCarrierGroups.flatMap((group) => group.passiveChipIds),
+    railCarrierGroups.flatMap((group) => group.passiveChipIds),
   )
 
   interface Candidate {
@@ -539,7 +393,7 @@ export const findSameSidePassiveGroups = (
   }
 
   const groups: SameSidePassiveGroup[] = [
-    ...unambiguousRailCarrierGroups,
+    ...railCarrierGroups,
     ...commonNodeGroups,
   ]
   for (const list of candidatesByGroup.values()) {

--- a/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
@@ -220,7 +220,9 @@ export const findSameSidePassiveGroups = (
 
   for (const candidates of railCarrierCandidatesByGroup.values()) {
     if (candidates.length < MIN_COMMON_NODE_PASSIVE_GROUP_SIZE) continue
-    const [{ mainChipId, side, carrierChipId }] = candidates
+    const firstCandidate = candidates[0]
+    if (!firstCandidate) continue
+    const { mainChipId, side, carrierChipId } = firstCandidate
     const carrierChip = problem.chipMap[carrierChipId]!
     const passiveChipIds = candidates.map(
       (candidate) => candidate.passiveChipId,

--- a/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
@@ -211,6 +211,7 @@ export const findSameSidePassiveGroups = (
     const carrierChip = problem.chipMap[first.carrierChipId]
     if (!carrierChip || carrierChip.pins.length !== 3) continue
 
+    sortRailCarrierCandidates(candidates)
     const passiveChipIds = candidates.map(
       (candidate) => candidate.passiveChipId,
     )
@@ -249,7 +250,6 @@ export const findSameSidePassiveGroups = (
     )
     if (!carrierPinsAreExclusive || railPins.length !== 1) continue
 
-    sortRailCarrierCandidates(candidates)
     railCarrierGroups.push({
       mainChipId: first.mainChipId,
       side: first.side,

--- a/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
@@ -121,8 +121,26 @@ const isRailCarrierPassiveLeaf = (chip: Chip): boolean =>
 const passiveSetKey = (passiveChipIds: ChipId[]): string =>
   [...passiveChipIds].sort().join("|")
 
+type StrongConnection = {
+  selfPin: PinId
+  otherPin: PinId
+  otherChip: ChipId
+}
+
+interface RailCarrierCandidate {
+  passiveChipId: ChipId
+  passiveMainPinId: PinId
+  passiveCarrierPinId: PinId
+  carrierPinId: PinId
+  mainChipPinId: PinId
+  edgeCoord: number
+  mainChipId: ChipId
+  side: Side
+  carrierChipId: ChipId
+}
+
 const hasOnlyExpectedStrongConnection = (
-  strongs: Array<{ selfPin: PinId; otherPin: PinId; otherChip: ChipId }>,
+  strongs: StrongConnection[],
   selfPin: PinId,
   expectedOtherPin: PinId,
   expectedOtherChip: ChipId,
@@ -138,6 +156,125 @@ const hasOnlyExpectedStrongConnection = (
   )
 }
 
+const hasUniqueValues = (values: string[]): boolean =>
+  new Set(values).size === values.length
+
+const sortRailCarrierCandidates = (
+  candidates: RailCarrierCandidate[],
+): void => {
+  candidates.sort((a, b) => {
+    if (a.edgeCoord !== b.edgeCoord) return a.edgeCoord - b.edgeCoord
+    return (
+      a.mainChipPinId.localeCompare(b.mainChipPinId) ||
+      a.passiveChipId.localeCompare(b.passiveChipId) ||
+      a.carrierPinId.localeCompare(b.carrierPinId)
+    )
+  })
+}
+
+const buildRailCarrierGroupIfValid = ({
+  problem,
+  candidates,
+  strongByChip,
+}: {
+  problem: InputProblem
+  candidates: RailCarrierCandidate[]
+  strongByChip: Map<ChipId, StrongConnection[]>
+}): SameSidePassiveGroup | null => {
+  if (candidates.length < MIN_COMMON_NODE_PASSIVE_GROUP_SIZE) return null
+  const firstCandidate = candidates[0]
+  if (!firstCandidate) return null
+
+  const { mainChipId, side, carrierChipId } = firstCandidate
+  if (
+    candidates.some(
+      (candidate) =>
+        candidate.mainChipId !== mainChipId ||
+        candidate.side !== side ||
+        candidate.carrierChipId !== carrierChipId,
+    )
+  ) {
+    return null
+  }
+
+  const carrierChip = problem.chipMap[carrierChipId]
+  if (!carrierChip) return null
+
+  const passiveChipIds = candidates.map((candidate) => candidate.passiveChipId)
+  if (!hasUniqueValues(passiveChipIds)) return null
+
+  const mainChipPinIds = candidates.map((candidate) => candidate.mainChipPinId)
+  if (!hasUniqueValues(mainChipPinIds)) return null
+
+  const edgeCoords = candidates.map((candidate) => `${candidate.edgeCoord}`)
+  if (!hasUniqueValues(edgeCoords)) return null
+
+  const carrierPinIds = candidates.map((candidate) => candidate.carrierPinId)
+  if (!hasUniqueValues(carrierPinIds)) return null
+
+  const claimedCarrierPins = new Set(carrierPinIds)
+  for (const carrierPinId of carrierChip.pins) {
+    const carrierPinStrongConnections = (
+      strongByChip.get(carrierChipId) ?? []
+    ).filter((strong) => strong.selfPin === carrierPinId)
+    if (claimedCarrierPins.has(carrierPinId)) {
+      const matchingPassiveConnections = carrierPinStrongConnections.filter(
+        (strong) => passiveChipIds.includes(strong.otherChip),
+      )
+      if (
+        matchingPassiveConnections.length !== 1 ||
+        carrierPinStrongConnections.length !== 1
+      ) {
+        return null
+      }
+      continue
+    }
+    if (carrierPinStrongConnections.length > 0) return null
+  }
+
+  const railPins = carrierChip.pins.filter(
+    (pinId) =>
+      !claimedCarrierPins.has(pinId) &&
+      getNetIdsForPin(problem, pinId).length === 1,
+  )
+  if (railPins.length !== 1) return null
+
+  const accountedCarrierPins = new Set([...carrierPinIds, railPins[0]!])
+  if (carrierChip.pins.some((pinId) => !accountedCarrierPins.has(pinId))) {
+    return null
+  }
+
+  sortRailCarrierCandidates(candidates)
+  return {
+    mainChipId,
+    side,
+    passiveChipIds: candidates.map((candidate) => candidate.passiveChipId),
+    mainChipPinIds: candidates.map((candidate) => candidate.mainChipPinId),
+    railCarrier: {
+      carrierChipId,
+      railPinId: railPins[0]!,
+      passiveMainPinIdsByChipId: Object.fromEntries(
+        candidates.map((candidate) => [
+          candidate.passiveChipId,
+          candidate.passiveMainPinId,
+        ]),
+      ),
+      passiveCarrierPinIdsByChipId: Object.fromEntries(
+        candidates.map((candidate) => [
+          candidate.passiveChipId,
+          candidate.passiveCarrierPinId,
+        ]),
+      ),
+      carrierPinIdsByPassiveChipId: Object.fromEntries(
+        candidates.map((candidate) => [
+          candidate.passiveChipId,
+          candidate.carrierPinId,
+        ]),
+      ),
+    },
+  }
+}
+
 /**
  * Find same-side passive groups in a partition. Returns one entry per group,
  * with its passives ordered along the main-chip edge.
@@ -150,10 +287,7 @@ export const findSameSidePassiveGroups = (
   const stronglyConnectedPinIds = new Set(pairs.flat())
 
   // Strong connections per chip: which pin connects out, and to which chip.
-  const strongByChip = new Map<
-    ChipId,
-    Array<{ selfPin: PinId; otherPin: PinId; otherChip: ChipId }>
-  >()
+  const strongByChip = new Map<ChipId, StrongConnection[]>()
   for (const [a, b] of pairs) {
     const chipA = pinToChip[a]
     const chipB = pinToChip[b]
@@ -165,24 +299,7 @@ export const findSameSidePassiveGroups = (
   }
 
   const railCarrierGroups: SameSidePassiveGroup[] = []
-  interface RailCarrierCandidate {
-    passiveChipId: ChipId
-    passiveMainPinId: PinId
-    passiveCarrierPinId: PinId
-    carrierPinId: PinId
-    mainChipPinId: PinId
-    edgeCoord: number
-  }
-  const railCarrierCandidatesByGroup = new Map<
-    string,
-    Array<
-      RailCarrierCandidate & {
-        mainChipId: ChipId
-        side: Side
-        carrierChipId: ChipId
-      }
-    >
-  >()
+  const railCarrierCandidatesByGroup = new Map<string, RailCarrierCandidate[]>()
 
   for (const [passiveChipId, passiveChip] of Object.entries(problem.chipMap)) {
     if (passiveChip.fixedPosition) continue
@@ -258,84 +375,12 @@ export const findSameSidePassiveGroups = (
   }
 
   for (const candidates of railCarrierCandidatesByGroup.values()) {
-    if (candidates.length < MIN_COMMON_NODE_PASSIVE_GROUP_SIZE) continue
-    const firstCandidate = candidates[0]
-    if (!firstCandidate) continue
-    const { mainChipId, side, carrierChipId } = firstCandidate
-    const carrierChip = problem.chipMap[carrierChipId]!
-    const passiveChipIds = candidates.map(
-      (candidate) => candidate.passiveChipId,
-    )
-    if (new Set(passiveChipIds).size !== passiveChipIds.length) continue
-    const carrierPinIds = candidates.map((candidate) => candidate.carrierPinId)
-    if (new Set(carrierPinIds).size !== carrierPinIds.length) continue
-
-    const claimedCarrierPins = new Set(carrierPinIds)
-    let hasAmbiguousCarrierBranch = false
-    for (const carrierPinId of carrierChip.pins) {
-      const carrierPinStrongConnections = (
-        strongByChip.get(carrierChipId) ?? []
-      ).filter((strong) => strong.selfPin === carrierPinId)
-      if (claimedCarrierPins.has(carrierPinId)) {
-        const matchingPassiveConnections = carrierPinStrongConnections.filter(
-          (strong) => passiveChipIds.includes(strong.otherChip),
-        )
-        if (
-          matchingPassiveConnections.length !== 1 ||
-          carrierPinStrongConnections.length !== 1
-        ) {
-          hasAmbiguousCarrierBranch = true
-          break
-        }
-        continue
-      }
-      if (carrierPinStrongConnections.length > 0) {
-        hasAmbiguousCarrierBranch = true
-        break
-      }
-    }
-    if (hasAmbiguousCarrierBranch) continue
-
-    const railPins = carrierChip.pins.filter(
-      (pinId) =>
-        !claimedCarrierPins.has(pinId) &&
-        getNetIdsForPin(problem, pinId).length === 1,
-    )
-    if (railPins.length !== 1) continue
-    const accountedCarrierPins = new Set([...carrierPinIds, railPins[0]!])
-    if (carrierChip.pins.some((pinId) => !accountedCarrierPins.has(pinId))) {
-      continue
-    }
-
-    candidates.sort((a, b) => a.edgeCoord - b.edgeCoord)
-    railCarrierGroups.push({
-      mainChipId,
-      side,
-      passiveChipIds: candidates.map((candidate) => candidate.passiveChipId),
-      mainChipPinIds: candidates.map((candidate) => candidate.mainChipPinId),
-      railCarrier: {
-        carrierChipId,
-        railPinId: railPins[0]!,
-        passiveMainPinIdsByChipId: Object.fromEntries(
-          candidates.map((candidate) => [
-            candidate.passiveChipId,
-            candidate.passiveMainPinId,
-          ]),
-        ),
-        passiveCarrierPinIdsByChipId: Object.fromEntries(
-          candidates.map((candidate) => [
-            candidate.passiveChipId,
-            candidate.passiveCarrierPinId,
-          ]),
-        ),
-        carrierPinIdsByPassiveChipId: Object.fromEntries(
-          candidates.map((candidate) => [
-            candidate.passiveChipId,
-            candidate.carrierPinId,
-          ]),
-        ),
-      },
+    const group = buildRailCarrierGroupIfValid({
+      problem,
+      candidates,
+      strongByChip,
     })
+    if (group) railCarrierGroups.push(group)
   }
 
   const ambiguousRailCarrierGroupKeys = new Set<string>()

--- a/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
@@ -121,6 +121,23 @@ const isRailCarrierPassiveLeaf = (chip: Chip): boolean =>
 const passiveSetKey = (passiveChipIds: ChipId[]): string =>
   [...passiveChipIds].sort().join("|")
 
+const hasOnlyExpectedStrongConnection = (
+  strongs: Array<{ selfPin: PinId; otherPin: PinId; otherChip: ChipId }>,
+  selfPin: PinId,
+  expectedOtherPin: PinId,
+  expectedOtherChip: ChipId,
+): boolean => {
+  const matchingSelfPinConnections = strongs.filter(
+    (strong) => strong.selfPin === selfPin,
+  )
+  if (matchingSelfPinConnections.length !== 1) return false
+  const connection = matchingSelfPinConnections[0]!
+  return (
+    connection.otherPin === expectedOtherPin &&
+    connection.otherChip === expectedOtherChip
+  )
+}
+
 /**
  * Find same-side passive groups in a partition. Returns one entry per group,
  * with its passives ordered along the main-chip edge.
@@ -179,6 +196,16 @@ export const findSameSidePassiveGroups = (
       if (!mainChip || !mainPin) continue
       if (mainChip.fixedPosition) continue
       if (mainChip.pins.length < MAIN_CHIP_MIN_PINS) continue
+      if (
+        !hasOnlyExpectedStrongConnection(
+          strongs,
+          strongToMain.selfPin,
+          strongToMain.otherPin,
+          mainChipId,
+        )
+      ) {
+        continue
+      }
 
       const passiveCarrierPinId = passiveChip.pins.find(
         (pinId) => pinId !== strongToMain.selfPin,
@@ -193,6 +220,16 @@ export const findSameSidePassiveGroups = (
       const carrierConnection = carrierStrongConnections[0]!
       const carrierChipId = carrierConnection.otherChip
       if (carrierChipId === mainChipId) continue
+      if (
+        !hasOnlyExpectedStrongConnection(
+          strongs,
+          passiveCarrierPinId,
+          carrierConnection.otherPin,
+          carrierChipId,
+        )
+      ) {
+        continue
+      }
       const carrierChip = problem.chipMap[carrierChipId]
       if (!carrierChip || carrierChip.fixedPosition) continue
       if (carrierChip.pins.length < MIN_COMMON_NODE_PASSIVE_GROUP_SIZE + 1)

--- a/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
@@ -118,6 +118,9 @@ const edgeCoordForSide = (
 const isRailCarrierPassiveLeaf = (chip: Chip): boolean =>
   chip.pins.length === PASSIVE_PIN_COUNT && chip.isResistor === true
 
+const passiveSetKey = (passiveChipIds: ChipId[]): string =>
+  [...passiveChipIds].sort().join("|")
+
 /**
  * Find same-side passive groups in a partition. Returns one entry per group,
  * with its passives ordered along the main-chip edge.
@@ -299,6 +302,37 @@ export const findSameSidePassiveGroups = (
     })
   }
 
+  const ambiguousRailCarrierGroupKeys = new Set<string>()
+  for (let i = 0; i < railCarrierGroups.length; i++) {
+    const group = railCarrierGroups[i]!
+    if (!group.railCarrier) continue
+    const groupPassiveKey = passiveSetKey(group.passiveChipIds)
+    for (let j = i + 1; j < railCarrierGroups.length; j++) {
+      const otherGroup = railCarrierGroups[j]!
+      const otherRailCarrier = otherGroup.railCarrier
+      if (!otherRailCarrier) continue
+      if (
+        group.mainChipId === otherRailCarrier.carrierChipId &&
+        group.railCarrier.carrierChipId === otherGroup.mainChipId &&
+        groupPassiveKey === passiveSetKey(otherGroup.passiveChipIds)
+      ) {
+        ambiguousRailCarrierGroupKeys.add(
+          `${group.mainChipId}|${group.railCarrier.carrierChipId}|${groupPassiveKey}`,
+        )
+        ambiguousRailCarrierGroupKeys.add(
+          `${otherGroup.mainChipId}|${otherRailCarrier.carrierChipId}|${groupPassiveKey}`,
+        )
+      }
+    }
+  }
+  const unambiguousRailCarrierGroups = railCarrierGroups.filter((group) => {
+    const railCarrier = group.railCarrier
+    if (!railCarrier) return true
+    return !ambiguousRailCarrierGroupKeys.has(
+      `${group.mainChipId}|${railCarrier.carrierChipId}|${passiveSetKey(group.passiveChipIds)}`,
+    )
+  })
+
   const commonNodeGroups: SameSidePassiveGroup[] = []
   for (const strongs of strongByChip.values()) {
     const strongsByPin = new Map<PinId, typeof strongs>()
@@ -358,7 +392,7 @@ export const findSameSidePassiveGroups = (
     commonNodeGroups.flatMap((group) => group.passiveChipIds),
   )
   const railCarrierPassiveChipIds = new Set(
-    railCarrierGroups.flatMap((group) => group.passiveChipIds),
+    unambiguousRailCarrierGroups.flatMap((group) => group.passiveChipIds),
   )
 
   interface Candidate {
@@ -424,7 +458,7 @@ export const findSameSidePassiveGroups = (
   }
 
   const groups: SameSidePassiveGroup[] = [
-    ...railCarrierGroups,
+    ...unambiguousRailCarrierGroups,
     ...commonNodeGroups,
   ]
   for (const list of candidatesByGroup.values()) {

--- a/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
@@ -33,6 +33,13 @@ export interface SameSidePassiveGroup {
   passiveChipIds: ChipId[]
   /** Main-chip pin each passive connects to, parallel to `passiveChipIds`. */
   mainChipPinIds: PinId[]
+  railCarrier?: {
+    carrierChipId: ChipId
+    railPinId: PinId
+    passiveMainPinIdsByChipId: Record<ChipId, PinId>
+    passiveCarrierPinIdsByChipId: Record<ChipId, PinId>
+    carrierPinIdsByPassiveChipId: Record<ChipId, PinId>
+  }
 }
 
 const buildPinToChip = (problem: InputProblem): Record<PinId, ChipId> => {
@@ -67,6 +74,16 @@ const getNetForPin = (problem: InputProblem, pinId: PinId): NetId | null => {
     return connKey.slice(pinId.length + 1)
   }
   return null
+}
+
+const getNetIdsForPin = (problem: InputProblem, pinId: PinId): NetId[] => {
+  const netIds: NetId[] = []
+  for (const [connKey, connected] of Object.entries(problem.netConnMap)) {
+    if (!connected) continue
+    if (!connKey.startsWith(`${pinId}-`)) continue
+    netIds.push(connKey.slice(pinId.length + 1))
+  }
+  return netIds
 }
 
 /** Main-chip side a pin offset points to once the chip's rotation is applied. */
@@ -116,6 +133,154 @@ export const findSameSidePassiveGroups = (
     if (!strongByChip.has(chipB)) strongByChip.set(chipB, [])
     strongByChip.get(chipA)!.push({ selfPin: a, otherPin: b, otherChip: chipB })
     strongByChip.get(chipB)!.push({ selfPin: b, otherPin: a, otherChip: chipA })
+  }
+
+  const railCarrierGroups: SameSidePassiveGroup[] = []
+  interface RailCarrierCandidate {
+    passiveChipId: ChipId
+    passiveMainPinId: PinId
+    passiveCarrierPinId: PinId
+    carrierPinId: PinId
+    mainChipPinId: PinId
+    edgeCoord: number
+  }
+  const railCarrierCandidatesByGroup = new Map<
+    string,
+    Array<
+      RailCarrierCandidate & {
+        mainChipId: ChipId
+        side: Side
+        carrierChipId: ChipId
+      }
+    >
+  >()
+
+  for (const [passiveChipId, passiveChip] of Object.entries(problem.chipMap)) {
+    if (passiveChip.fixedPosition) continue
+    if (passiveChip.pins.length !== PASSIVE_PIN_COUNT) continue
+
+    const strongs = strongByChip.get(passiveChipId) ?? []
+    for (const strongToMain of strongs) {
+      const mainChipId = strongToMain.otherChip
+      const mainChip = problem.chipMap[mainChipId]
+      const mainPin = problem.chipPinMap[strongToMain.otherPin]
+      if (!mainChip || !mainPin) continue
+      if (mainChip.fixedPosition) continue
+      if (mainChip.pins.length < MAIN_CHIP_MIN_PINS) continue
+
+      const passiveCarrierPinId = passiveChip.pins.find(
+        (pinId) => pinId !== strongToMain.selfPin,
+      )
+      if (!passiveCarrierPinId) continue
+
+      const carrierStrongConnections = strongs.filter(
+        (strong) => strong.selfPin === passiveCarrierPinId,
+      )
+      if (carrierStrongConnections.length !== 1) continue
+
+      const carrierConnection = carrierStrongConnections[0]!
+      const carrierChipId = carrierConnection.otherChip
+      if (carrierChipId === mainChipId) continue
+      const carrierChip = problem.chipMap[carrierChipId]
+      if (!carrierChip || carrierChip.fixedPosition) continue
+      if (carrierChip.pins.length < 3 || carrierChip.pins.length > 4) continue
+
+      const mainChipRotation = mainChip.availableRotations?.[0] ?? 0
+      const mainChipPinOffset = rotatePinOffset(
+        mainPin.offset,
+        mainChipRotation,
+      )
+      const side = getMainChipPinSide(mainPin.offset, mainChipRotation)
+      const key = `${mainChipId}|${side}|${carrierChipId}`
+      const candidates = railCarrierCandidatesByGroup.get(key) ?? []
+      candidates.push({
+        passiveChipId,
+        passiveMainPinId: strongToMain.selfPin,
+        passiveCarrierPinId,
+        carrierPinId: carrierConnection.otherPin,
+        mainChipPinId: strongToMain.otherPin,
+        edgeCoord: edgeCoordForSide(mainChipPinOffset, side),
+        mainChipId,
+        side,
+        carrierChipId,
+      })
+      railCarrierCandidatesByGroup.set(key, candidates)
+    }
+  }
+
+  for (const candidates of railCarrierCandidatesByGroup.values()) {
+    if (candidates.length < MIN_COMMON_NODE_PASSIVE_GROUP_SIZE) continue
+    const [{ mainChipId, side, carrierChipId }] = candidates
+    const carrierChip = problem.chipMap[carrierChipId]!
+    const passiveChipIds = candidates.map(
+      (candidate) => candidate.passiveChipId,
+    )
+    if (new Set(passiveChipIds).size !== passiveChipIds.length) continue
+    const carrierPinIds = candidates.map((candidate) => candidate.carrierPinId)
+    if (new Set(carrierPinIds).size !== carrierPinIds.length) continue
+
+    const claimedCarrierPins = new Set(carrierPinIds)
+    let hasAmbiguousCarrierBranch = false
+    for (const carrierPinId of carrierChip.pins) {
+      const carrierPinStrongConnections = (
+        strongByChip.get(carrierChipId) ?? []
+      ).filter((strong) => strong.selfPin === carrierPinId)
+      if (claimedCarrierPins.has(carrierPinId)) {
+        const matchingPassiveConnections = carrierPinStrongConnections.filter(
+          (strong) => passiveChipIds.includes(strong.otherChip),
+        )
+        if (
+          matchingPassiveConnections.length !== 1 ||
+          carrierPinStrongConnections.length !== 1
+        ) {
+          hasAmbiguousCarrierBranch = true
+          break
+        }
+        continue
+      }
+      if (carrierPinStrongConnections.length > 0) {
+        hasAmbiguousCarrierBranch = true
+        break
+      }
+    }
+    if (hasAmbiguousCarrierBranch) continue
+
+    const railPins = carrierChip.pins.filter(
+      (pinId) =>
+        !claimedCarrierPins.has(pinId) &&
+        getNetIdsForPin(problem, pinId).length === 1,
+    )
+    if (railPins.length !== 1) continue
+
+    candidates.sort((a, b) => a.edgeCoord - b.edgeCoord)
+    railCarrierGroups.push({
+      mainChipId,
+      side,
+      passiveChipIds: candidates.map((candidate) => candidate.passiveChipId),
+      mainChipPinIds: candidates.map((candidate) => candidate.mainChipPinId),
+      railCarrier: {
+        carrierChipId,
+        railPinId: railPins[0]!,
+        passiveMainPinIdsByChipId: Object.fromEntries(
+          candidates.map((candidate) => [
+            candidate.passiveChipId,
+            candidate.passiveMainPinId,
+          ]),
+        ),
+        passiveCarrierPinIdsByChipId: Object.fromEntries(
+          candidates.map((candidate) => [
+            candidate.passiveChipId,
+            candidate.passiveCarrierPinId,
+          ]),
+        ),
+        carrierPinIdsByPassiveChipId: Object.fromEntries(
+          candidates.map((candidate) => [
+            candidate.passiveChipId,
+            candidate.carrierPinId,
+          ]),
+        ),
+      },
+    })
   }
 
   const commonNodeGroups: SameSidePassiveGroup[] = []
@@ -176,6 +341,9 @@ export const findSameSidePassiveGroups = (
   const commonNodePassiveChipIds = new Set(
     commonNodeGroups.flatMap((group) => group.passiveChipIds),
   )
+  const railCarrierPassiveChipIds = new Set(
+    railCarrierGroups.flatMap((group) => group.passiveChipIds),
+  )
 
   interface Candidate {
     passiveChipId: ChipId
@@ -188,6 +356,7 @@ export const findSameSidePassiveGroups = (
   const candidates: Candidate[] = []
 
   for (const [passiveChipId, passiveChip] of Object.entries(problem.chipMap)) {
+    if (railCarrierPassiveChipIds.has(passiveChipId)) continue
     if (commonNodePassiveChipIds.has(passiveChipId)) continue
     if (passiveChip.pins.length !== PASSIVE_PIN_COUNT) continue
 
@@ -238,7 +407,10 @@ export const findSameSidePassiveGroups = (
     candidatesByGroup.set(key, list)
   }
 
-  const groups: SameSidePassiveGroup[] = [...commonNodeGroups]
+  const groups: SameSidePassiveGroup[] = [
+    ...railCarrierGroups,
+    ...commonNodeGroups,
+  ]
   for (const list of candidatesByGroup.values()) {
     if (list.length < MIN_PASSIVE_GROUP_SIZE) continue
     list.sort((a, b) => a.edgeCoord - b.edgeCoord)

--- a/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
@@ -194,7 +194,6 @@ export const findSameSidePassiveGroups = (
       const mainChip = problem.chipMap[mainChipId]
       const mainPin = problem.chipPinMap[strongToMain.otherPin]
       if (!mainChip || !mainPin) continue
-      if (mainChip.fixedPosition) continue
       if (mainChip.pins.length < MAIN_CHIP_MIN_PINS) continue
       if (
         !hasOnlyExpectedStrongConnection(

--- a/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
+++ b/lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups.ts
@@ -17,7 +17,13 @@
  * layout and re-flows just the group into a clean row.
  */
 
-import type { ChipId, InputProblem, NetId, PinId } from "lib/types/InputProblem"
+import type {
+  Chip,
+  ChipId,
+  InputProblem,
+  NetId,
+  PinId,
+} from "lib/types/InputProblem"
 import type { Side } from "lib/types/Side"
 import { rotatePinOffset } from "lib/utils/rotatePinOffset"
 
@@ -109,6 +115,9 @@ const edgeCoordForSide = (
   return offset.x
 }
 
+const isRailCarrierPassiveLeaf = (chip: Chip): boolean =>
+  chip.pins.length === PASSIVE_PIN_COUNT && chip.isResistor === true
+
 /**
  * Find same-side passive groups in a partition. Returns one entry per group,
  * with its passives ordered along the main-chip edge.
@@ -157,7 +166,7 @@ export const findSameSidePassiveGroups = (
 
   for (const [passiveChipId, passiveChip] of Object.entries(problem.chipMap)) {
     if (passiveChip.fixedPosition) continue
-    if (passiveChip.pins.length !== PASSIVE_PIN_COUNT) continue
+    if (!isRailCarrierPassiveLeaf(passiveChip)) continue
 
     const strongs = strongByChip.get(passiveChipId) ?? []
     for (const strongToMain of strongs) {
@@ -183,7 +192,8 @@ export const findSameSidePassiveGroups = (
       if (carrierChipId === mainChipId) continue
       const carrierChip = problem.chipMap[carrierChipId]
       if (!carrierChip || carrierChip.fixedPosition) continue
-      if (carrierChip.pins.length < 3 || carrierChip.pins.length > 4) continue
+      if (carrierChip.pins.length < MIN_COMMON_NODE_PASSIVE_GROUP_SIZE + 1)
+        continue
 
       const mainChipRotation = mainChip.availableRotations?.[0] ?? 0
       const mainChipPinOffset = rotatePinOffset(
@@ -251,6 +261,10 @@ export const findSameSidePassiveGroups = (
         getNetIdsForPin(problem, pinId).length === 1,
     )
     if (railPins.length !== 1) continue
+    const accountedCarrierPins = new Set([...carrierPinIds, railPins[0]!])
+    if (carrierChip.pins.some((pinId) => !accountedCarrierPins.has(pinId))) {
+      continue
+    }
 
     candidates.sort((a, b) => a.edgeCoord - b.edgeCoord)
     railCarrierGroups.push({

--- a/pages/repros/repro-si7021/si7021-matchpack-input.json
+++ b/pages/repros/repro-si7021/si7021-matchpack-input.json
@@ -16,13 +16,15 @@
       "chipId": "R1",
       "pins": ["R1.1", "R1.2"],
       "size": { "x": 0.5, "y": 1.0 },
-      "availableRotations": [0, 90, 180, 270]
+      "availableRotations": [0, 90, 180, 270],
+      "isResistor": true
     },
     "R2": {
       "chipId": "R2",
       "pins": ["R2.1", "R2.2"],
       "size": { "x": 0.5, "y": 1.0 },
-      "availableRotations": [0, 90, 180, 270]
+      "availableRotations": [0, 90, 180, 270],
+      "isResistor": true
     },
     "SJ1": {
       "chipId": "SJ1",

--- a/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
+++ b/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
@@ -17,6 +17,8 @@ const makeRailCarrierProblem = (
     fixedCarrier?: boolean
     fixedPassive?: boolean
     fixedMain?: boolean
+    fixedMainPosition?: { x: number; y: number }
+    fixedMainRotation?: 0 | 90 | 180 | 270
     branchedMainFacingPin?: boolean
     branchedCarrierFacingPin?: boolean
     customNet?: boolean
@@ -40,8 +42,13 @@ const makeRailCarrierProblem = (
         chipId: main,
         pins: [`${main}.1`, `${main}.2`, `${main}.3`, `${main}.4`],
         size: { x: 1.2, y: 0.8 },
-        availableRotations: [0, 90, 180, 270],
-        ...(opts.fixedMain && { fixedPosition: { x: 0, y: 0 } }),
+        availableRotations:
+          opts.fixedMainRotation !== undefined
+            ? [opts.fixedMainRotation]
+            : [0, 90, 180, 270],
+        ...(opts.fixedMain && {
+          fixedPosition: opts.fixedMainPosition ?? { x: 0, y: 0 },
+        }),
       },
       [upperPassive]: {
         chipId: upperPassive,
@@ -759,6 +766,66 @@ test("detects rail-carrier topology with arbitrary component ids", () => {
   expect(groups[0]!.passiveChipIds).toEqual(["pullup_lower", "pullup_upper"])
 })
 
+test("detects rail-carrier topology around a fixed main chip", () => {
+  const groups = findSameSidePassiveGroups(
+    makeRailCarrierProblem({ fixedMain: true }),
+  )
+
+  expect(groups).toHaveLength(1)
+  expect(groups[0]!.mainChipId).toBe("U1")
+  expect(groups[0]!.railCarrier?.carrierChipId).toBe("SJ1")
+  expect(groups[0]!.passiveChipIds).toEqual(["R2", "R1"])
+})
+
+test("reflows rail-carrier passives around fixed main chips without moving them", () => {
+  const cases = [
+    { fixedMainPosition: { x: 0, y: 0 }, fixedMainRotation: 0 },
+    { fixedMainPosition: { x: 10, y: 5 }, fixedMainRotation: 0 },
+    { fixedMainPosition: { x: -7, y: -4 }, fixedMainRotation: 0 },
+    { fixedMainPosition: { x: 100, y: -80 }, fixedMainRotation: 0 },
+    { fixedMainPosition: { x: 0, y: 0 }, fixedMainRotation: 90 },
+    { fixedMainPosition: { x: 0, y: 0 }, fixedMainRotation: 180 },
+    { fixedMainPosition: { x: 0, y: 0 }, fixedMainRotation: 270 },
+  ] as const
+
+  for (const testCase of cases) {
+    const inputProblem = makeRailCarrierProblem({
+      fixedMain: true,
+      fixedMainPosition: testCase.fixedMainPosition,
+      fixedMainRotation: testCase.fixedMainRotation,
+    })
+    const solver = new LayoutPipelineSolver(inputProblem)
+    solver.solve()
+    const layout = solver.getOutputLayout()
+
+    expect(
+      solver.packInnerPartitionsSolver?.completedSolvers[0]?.constructor.name,
+    ).toBe("ParallelAlignedPassiveSolver")
+    expectPlacementToEqual(layout.chipPlacements.U1!, {
+      ...testCase.fixedMainPosition,
+      ccwRotationDegrees: testCase.fixedMainRotation,
+    })
+    expect(solver.checkForOverlaps(layout)).toHaveLength(0)
+    for (const { distance } of getDistancesFromMovedGroup(
+      inputProblem,
+      layout,
+    )) {
+      expect(distance).toBeGreaterThanOrEqual(inputProblem.chipGap - 1e-6)
+    }
+  }
+})
+
+test("uses fixed main-chip rotation when ordering rail-carrier passives", () => {
+  const groups = findSameSidePassiveGroups(
+    makeRailCarrierProblem({ fixedMain: true, fixedMainRotation: 90 }),
+  )
+
+  expect(groups).toHaveLength(1)
+  expect(groups[0]!.side).toBe("y+")
+  expect(groups[0]!.passiveChipIds).toEqual(["R1", "R2"])
+  expect(groups[0]!.mainChipPinIds).toEqual(["U1.4", "U1.3"])
+})
+
 test("declines rail-carrier topology when a resistor main-facing pin is branched", () => {
   expect(
     findSameSidePassiveGroups(
@@ -792,6 +859,17 @@ test("declines rail-carrier topology when a resistor carrier-facing pin is branc
   ).toHaveLength(0)
 })
 
+test("declines fixed-main rail-carrier topology when a resistor pin is branched", () => {
+  expect(
+    findSameSidePassiveGroups(
+      makeRailCarrierProblem({
+        fixedMain: true,
+        branchedMainFacingPin: true,
+      }),
+    ),
+  ).toHaveLength(0)
+})
+
 test("detects four-passive rail-carrier topology without a pin-count ceiling", () => {
   const groups = findSameSidePassiveGroups(
     makeMultiPassiveRailCarrierProblem({ passiveCount: 4 }),
@@ -818,6 +896,14 @@ test("declines symmetric mirrored rail-carrier topology", () => {
   expect(groups).toHaveLength(0)
 })
 
+test("declines mirrored rail-carrier topology when mirrored endpoints are fixed", () => {
+  const problem = makeMirroredRailCarrierProblem()
+  problem.chipMap.A!.fixedPosition = { x: 0, y: 0 }
+  problem.chipMap.B!.fixedPosition = { x: 4, y: 0 }
+
+  expect(findSameSidePassiveGroups(problem)).toHaveLength(0)
+})
+
 test("keeps dense rail-carrier passives at least chipGap apart", () => {
   const inputProblem = makeDenseRailCarrierGapProblem()
   const solver = new LayoutPipelineSolver(inputProblem)
@@ -832,6 +918,26 @@ test("keeps dense rail-carrier passives at least chipGap apart", () => {
   expect(getBoundsDistance(r1Bounds, r2Bounds)).toBeGreaterThanOrEqual(
     inputProblem.chipGap - 1e-6,
   )
+})
+
+test("keeps dense fixed-main rail-carrier passives at least chipGap apart", () => {
+  const inputProblem = makeDenseRailCarrierGapProblem()
+  inputProblem.chipMap.U1!.fixedPosition = { x: 0, y: 0 }
+  const solver = new LayoutPipelineSolver(inputProblem)
+  solver.solve()
+  const layout = solver.getOutputLayout()
+
+  expect(
+    solver.packInnerPartitionsSolver?.completedSolvers[0]?.constructor.name,
+  ).toBe("ParallelAlignedPassiveSolver")
+  expectPlacementToEqual(layout.chipPlacements.U1!, {
+    x: 0,
+    y: 0,
+    ccwRotationDegrees: 0,
+  })
+  for (const { distance } of getDistancesFromMovedGroup(inputProblem, layout)) {
+    expect(distance).toBeGreaterThanOrEqual(inputProblem.chipGap - 1e-6)
+  }
 })
 
 test("rejects rail-carrier reflow that would violate chipGap to an unrelated obstacle", () => {
@@ -861,6 +967,22 @@ test("rejects rail-carrier reflow that would violate chipGap to an unrelated obs
 
   const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
   for (const chipId of ["R1", "R2", "SJ1"]) {
+    expectPlacementToEqual(
+      layout.chipPlacements[chipId]!,
+      baseLayout.chipPlacements[chipId]!,
+    )
+  }
+})
+
+test("fixed-main obstacle fallback leaves the main and rail group atomically packed", () => {
+  const { inputProblem, baseLayout } = makeRailCarrierObstacleProblem({
+    targetChipId: "R2",
+    clearance: 0.1,
+  })
+  inputProblem.chipMap.U1!.fixedPosition = { x: 0, y: 0 }
+  const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
+
+  for (const chipId of ["U1", "R1", "R2", "SJ1"]) {
     expectPlacementToEqual(
       layout.chipPlacements[chipId]!,
       baseLayout.chipPlacements[chipId]!,
@@ -1019,11 +1141,21 @@ test("declines rail-carrier topology when the carrier is fixed", () => {
   expect(
     findSameSidePassiveGroups(makeRailCarrierProblem({ fixedCarrier: true })),
   ).toHaveLength(0)
+  expect(
+    findSameSidePassiveGroups(
+      makeRailCarrierProblem({ fixedMain: true, fixedCarrier: true }),
+    ),
+  ).toHaveLength(0)
 })
 
 test("declines rail-carrier topology when a passive is fixed", () => {
   expect(
     findSameSidePassiveGroups(makeRailCarrierProblem({ fixedPassive: true })),
+  ).toHaveLength(0)
+  expect(
+    findSameSidePassiveGroups(
+      makeRailCarrierProblem({ fixedMain: true, fixedPassive: true }),
+    ),
   ).toHaveLength(0)
 })
 

--- a/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
+++ b/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
@@ -918,6 +918,49 @@ test("detects rail-carrier topology after record reordering", () => {
   expect(groups[0]!.passiveChipIds).toEqual(["R2", "R1"])
 })
 
+test("keeps carrier pins paired with passives after edge-order sorting", () => {
+  const reversedEnumeration = makeRailCarrierProblem()
+  const edgeOrdered = makeRailCarrierProblem()
+  edgeOrdered.chipMap = {
+    U1: edgeOrdered.chipMap.U1!,
+    R2: edgeOrdered.chipMap.R2!,
+    R1: edgeOrdered.chipMap.R1!,
+    SJ1: edgeOrdered.chipMap.SJ1!,
+  }
+
+  const reversedGroups = findSameSidePassiveGroups(reversedEnumeration)
+  const edgeOrderedGroups = findSameSidePassiveGroups(edgeOrdered)
+
+  expect(reversedGroups).toHaveLength(1)
+  expect(edgeOrderedGroups).toHaveLength(1)
+  expect(reversedGroups[0]!.passiveChipIds).toEqual(["R2", "R1"])
+  expect(reversedGroups[0]!.railCarrier?.passiveCarrierPinIds).toEqual([
+    "R2.2",
+    "R1.2",
+  ])
+  expect(reversedGroups[0]!.railCarrier?.carrierPinIds).toEqual([
+    "SJ1.1",
+    "SJ1.3",
+  ])
+  expect(reversedGroups[0]!.railCarrier).toEqual(
+    edgeOrderedGroups[0]!.railCarrier,
+  )
+
+  const reversedLayout = alignRailCarrierFromPackedLayout(
+    reversedEnumeration,
+    makeRailCarrierPackedLayout(),
+  )
+  const edgeOrderedLayout = alignRailCarrierFromPackedLayout(
+    edgeOrdered,
+    makeRailCarrierPackedLayout(),
+  )
+
+  expect(reversedLayout.chipPlacements).toEqual(
+    edgeOrderedLayout.chipPlacements,
+  )
+  expect(reversedLayout.chipPlacements.SJ1?.ccwRotationDegrees).toBe(90)
+})
+
 test("declines unsupported rail-carrier topology variants", () => {
   const mutateRailCarrierProblem = (
     mutate: (inputProblem: InputProblem) => void,
@@ -1118,7 +1161,7 @@ test("uses the actual packed main rotation for rail-carrier side and order", () 
     layout.chipPlacements.U1!,
   )
 
-  expect(layout.chipPlacements.SJ1!.ccwRotationDegrees).toBe(0)
+  expect(layout.chipPlacements.SJ1!.ccwRotationDegrees).toBe(180)
   for (const passiveChipId of ["R1", "R2", "SJ1"]) {
     const bounds = getChipBounds(
       inputProblem,
@@ -1133,7 +1176,7 @@ test("uses the actual packed main rotation for rail-carrier side and order", () 
 
 test("fails closed for reversed or ambiguous carrier pin ordering", () => {
   const reversed = makeRailCarrierProblem()
-  reversed.chipMap.SJ1!.availableRotations = [90]
+  reversed.chipMap.SJ1!.availableRotations = [270]
 
   const ambiguous = makeRailCarrierProblem()
   ambiguous.chipMap.SJ1!.availableRotations = [0, 90]

--- a/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
+++ b/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
@@ -1,0 +1,351 @@
+import { expect, test } from "bun:test"
+import { LayoutPipelineSolver } from "lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver"
+import { findSameSidePassiveGroups } from "lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups"
+import type { InputProblem } from "lib/types/InputProblem"
+import { rotatePinOffset } from "lib/utils/rotatePinOffset"
+import si7021Input from "../../pages/repros/repro-si7021/si7021-matchpack-input.json"
+import commonNodeInput from "../assets/repro-core-repro70-common-node-placement.input.json"
+
+const makeRailCarrierProblem = (
+  opts: {
+    customIds?: boolean
+    differentCarriers?: boolean
+    ambiguousCarrierBranch?: boolean
+    multipleRailPins?: boolean
+    fixedCarrier?: boolean
+    fixedPassive?: boolean
+  } = {},
+): InputProblem => {
+  const main = opts.customIds ? "sensor_controller" : "U1"
+  const upperPassive = opts.customIds ? "pullup_upper" : "R1"
+  const lowerPassive = opts.customIds ? "pullup_lower" : "R2"
+  const carrierA = opts.customIds ? "selectable_bridge_a" : "SJ1"
+  const carrierB = opts.customIds ? "selectable_bridge_b" : "SJ2"
+  const lowerCarrier = opts.differentCarriers ? carrierB : carrierA
+  const carrierPins =
+    opts.ambiguousCarrierBranch || opts.multipleRailPins
+      ? [`${carrierA}.1`, `${carrierA}.2`, `${carrierA}.3`, `${carrierA}.4`]
+      : [`${carrierA}.1`, `${carrierA}.2`, `${carrierA}.3`]
+
+  return {
+    chipMap: {
+      [main]: {
+        chipId: main,
+        pins: [`${main}.1`, `${main}.2`, `${main}.3`, `${main}.4`],
+        size: { x: 1.2, y: 0.8 },
+        availableRotations: [0, 90, 180, 270],
+      },
+      [upperPassive]: {
+        chipId: upperPassive,
+        pins: [`${upperPassive}.1`, `${upperPassive}.2`],
+        size: { x: 0.5, y: 1 },
+        availableRotations: [0, 90, 180, 270],
+        ...(opts.fixedPassive && { fixedPosition: { x: 2, y: 1 } }),
+      },
+      [lowerPassive]: {
+        chipId: lowerPassive,
+        pins: [`${lowerPassive}.1`, `${lowerPassive}.2`],
+        size: { x: 0.5, y: 1 },
+        availableRotations: [0, 90, 180, 270],
+      },
+      [carrierA]: {
+        chipId: carrierA,
+        pins: carrierPins,
+        size: { x: 0.6, y: 0.6 },
+        availableRotations: [0, 90, 180, 270],
+        ...(opts.fixedCarrier && { fixedPosition: { x: 3, y: 0 } }),
+      },
+      ...(opts.differentCarriers && {
+        [carrierB]: {
+          chipId: carrierB,
+          pins: [`${carrierB}.1`, `${carrierB}.2`, `${carrierB}.3`],
+          size: { x: 0.6, y: 0.6 },
+          availableRotations: [0, 90, 180, 270],
+        },
+      }),
+      ...(opts.ambiguousCarrierBranch && {
+        branch_load: {
+          chipId: "branch_load",
+          pins: ["branch_load.1", "branch_load.2"],
+          size: { x: 0.5, y: 1 },
+          availableRotations: [0, 90, 180, 270],
+        },
+      }),
+    },
+    chipPinMap: {
+      [`${main}.1`]: {
+        pinId: `${main}.1`,
+        side: "x-",
+        offset: { x: -1, y: 0.2 },
+      },
+      [`${main}.2`]: {
+        pinId: `${main}.2`,
+        side: "x-",
+        offset: { x: -1, y: 0 },
+      },
+      [`${main}.3`]: {
+        pinId: `${main}.3`,
+        side: "x+",
+        offset: { x: 1, y: -0.2 },
+      },
+      [`${main}.4`]: {
+        pinId: `${main}.4`,
+        side: "x+",
+        offset: { x: 1, y: 0.2 },
+      },
+      [`${upperPassive}.1`]: {
+        pinId: `${upperPassive}.1`,
+        side: "y+",
+        offset: { x: 0, y: 0.5 },
+      },
+      [`${upperPassive}.2`]: {
+        pinId: `${upperPassive}.2`,
+        side: "y-",
+        offset: { x: 0, y: -0.5 },
+      },
+      [`${lowerPassive}.1`]: {
+        pinId: `${lowerPassive}.1`,
+        side: "y+",
+        offset: { x: 0, y: 0.5 },
+      },
+      [`${lowerPassive}.2`]: {
+        pinId: `${lowerPassive}.2`,
+        side: "y-",
+        offset: { x: 0, y: -0.5 },
+      },
+      [`${carrierA}.1`]: {
+        pinId: `${carrierA}.1`,
+        side: "x-",
+        offset: { x: -0.3, y: 0 },
+      },
+      [`${carrierA}.2`]: {
+        pinId: `${carrierA}.2`,
+        side: "y+",
+        offset: { x: 0, y: 0.3 },
+      },
+      [`${carrierA}.3`]: {
+        pinId: `${carrierA}.3`,
+        side: "x+",
+        offset: { x: 0.3, y: 0 },
+      },
+      ...(carrierPins.includes(`${carrierA}.4`) && {
+        [`${carrierA}.4`]: {
+          pinId: `${carrierA}.4`,
+          side: "y-",
+          offset: { x: 0, y: -0.3 },
+        },
+      }),
+      ...(opts.differentCarriers && {
+        [`${carrierB}.1`]: {
+          pinId: `${carrierB}.1`,
+          side: "x-",
+          offset: { x: -0.3, y: 0 },
+        },
+        [`${carrierB}.2`]: {
+          pinId: `${carrierB}.2`,
+          side: "y+",
+          offset: { x: 0, y: 0.3 },
+        },
+        [`${carrierB}.3`]: {
+          pinId: `${carrierB}.3`,
+          side: "x+",
+          offset: { x: 0.3, y: 0 },
+        },
+      }),
+      ...(opts.ambiguousCarrierBranch && {
+        "branch_load.1": {
+          pinId: "branch_load.1",
+          side: "y+",
+          offset: { x: 0, y: 0.5 },
+        },
+        "branch_load.2": {
+          pinId: "branch_load.2",
+          side: "y-",
+          offset: { x: 0, y: -0.5 },
+        },
+      }),
+    },
+    netMap: {
+      RAIL: { netId: "RAIL" },
+      ...(opts.multipleRailPins && { OTHER_RAIL: { netId: "OTHER_RAIL" } }),
+    },
+    pinStrongConnMap: {
+      [`${main}.4-${upperPassive}.1`]: true,
+      [`${main}.3-${lowerPassive}.1`]: true,
+      [`${upperPassive}.2-${carrierA}.3`]: true,
+      [`${lowerPassive}.2-${lowerCarrier}.1`]: true,
+      ...(opts.ambiguousCarrierBranch && {
+        [`${carrierA}.4-branch_load.1`]: true,
+      }),
+    },
+    netConnMap: {
+      [`${carrierA}.2-RAIL`]: true,
+      ...(opts.differentCarriers && { [`${carrierB}.2-RAIL`]: true }),
+      ...(opts.multipleRailPins && { [`${carrierA}.4-OTHER_RAIL`]: true }),
+    },
+    chipGap: 0.4,
+    partitionGap: 1.2,
+  }
+}
+
+const getStrongEdgeMetrics = (inputProblem: InputProblem) => {
+  const solver = new LayoutPipelineSolver(inputProblem)
+  solver.solve()
+  const layout = solver.getOutputLayout()
+  const pinToChip = new Map<string, string>()
+  for (const [chipId, chip] of Object.entries(inputProblem.chipMap)) {
+    for (const pinId of chip.pins) pinToChip.set(pinId, chipId)
+  }
+
+  const edges = Object.keys(inputProblem.pinStrongConnMap)
+    .map((connKey) => connKey.split("-") as [string, string])
+    .filter(
+      ([a, b]) => inputProblem.chipPinMap[a] && inputProblem.chipPinMap[b],
+    )
+    .map(([a, b]) => {
+      const chipA = pinToChip.get(a)!
+      const chipB = pinToChip.get(b)!
+      const placementA = layout.chipPlacements[chipA]!
+      const placementB = layout.chipPlacements[chipB]!
+      const offsetA = rotatePinOffset(
+        inputProblem.chipPinMap[a]!.offset,
+        placementA.ccwRotationDegrees,
+      )
+      const offsetB = rotatePinOffset(
+        inputProblem.chipPinMap[b]!.offset,
+        placementB.ccwRotationDegrees,
+      )
+      const dx = placementB.x + offsetB.x - (placementA.x + offsetA.x)
+      const dy = placementB.y + offsetB.y - (placementA.y + offsetA.y)
+      return {
+        edge: `${a}-${b}`,
+        manhattan: Math.abs(dx) + Math.abs(dy),
+        offAxis: Math.min(Math.abs(dx), Math.abs(dy)),
+      }
+    })
+
+  return {
+    solver,
+    edges,
+    totalManhattan: edges.reduce((sum, edge) => sum + edge.manhattan, 0),
+    maxOffAxis: Math.max(...edges.map((edge) => edge.offAxis)),
+  }
+}
+
+test("detects the original SI7021 passive rail-carrier topology", () => {
+  const groups = findSameSidePassiveGroups(si7021Input as InputProblem)
+
+  expect(groups).toHaveLength(1)
+  expect(groups[0]!.railCarrier?.carrierChipId).toBe("SJ1")
+  expect(groups[0]!.passiveChipIds).toEqual(["R2", "R1"])
+})
+
+test("lays out SI7021 rail-carrier passives with materially lower off-axis error", () => {
+  const { solver, totalManhattan, maxOffAxis } = getStrongEdgeMetrics(
+    si7021Input as InputProblem,
+  )
+
+  expect(
+    solver.packInnerPartitionsSolver?.completedSolvers[0]?.constructor.name,
+  ).toBe("ParallelAlignedPassiveSolver")
+  expect(solver.checkForOverlaps(solver.getOutputLayout())).toHaveLength(0)
+  expect(totalManhattan).toBeLessThan(5.9)
+  expect(maxOffAxis).toBeLessThanOrEqual(0.125)
+})
+
+test("detects rail-carrier topology with arbitrary component ids", () => {
+  const groups = findSameSidePassiveGroups(
+    makeRailCarrierProblem({ customIds: true }),
+  )
+
+  expect(groups).toHaveLength(1)
+  expect(groups[0]!.railCarrier?.carrierChipId).toBe("selectable_bridge_a")
+  expect(groups[0]!.passiveChipIds).toEqual(["pullup_lower", "pullup_upper"])
+})
+
+test("declines same-side passives attached to unrelated downstream parts", () => {
+  expect(
+    findSameSidePassiveGroups(
+      makeRailCarrierProblem({ differentCarriers: true }),
+    ),
+  ).toHaveLength(0)
+})
+
+test("declines a shared carrier with an extra branch", () => {
+  expect(
+    findSameSidePassiveGroups(
+      makeRailCarrierProblem({ ambiguousCarrierBranch: true }),
+    ),
+  ).toHaveLength(0)
+})
+
+test("declines a shared carrier with multiple possible rail pins", () => {
+  expect(
+    findSameSidePassiveGroups(
+      makeRailCarrierProblem({ multipleRailPins: true }),
+    ),
+  ).toHaveLength(0)
+})
+
+test("declines rail-carrier topology when the carrier is fixed", () => {
+  expect(
+    findSameSidePassiveGroups(makeRailCarrierProblem({ fixedCarrier: true })),
+  ).toHaveLength(0)
+})
+
+test("declines rail-carrier topology when a passive is fixed", () => {
+  expect(
+    findSameSidePassiveGroups(makeRailCarrierProblem({ fixedPassive: true })),
+  ).toHaveLength(0)
+})
+
+test("preserves existing common-node passive detection", () => {
+  const groups = findSameSidePassiveGroups(commonNodeInput as InputProblem)
+
+  expect(groups).toHaveLength(1)
+  expect(groups[0]!.railCarrier).toBeUndefined()
+  expect(groups[0]!.passiveChipIds).toEqual(["C1", "C3"])
+})
+
+test("preserves existing three-passive same-side detection", () => {
+  const problem = makeRailCarrierProblem()
+  problem.chipMap.C3 = {
+    chipId: "C3",
+    pins: ["C3.1", "C3.2"],
+    size: { x: 0.5, y: 1 },
+    availableRotations: [0, 90, 180, 270],
+  }
+  problem.chipMap.U1!.pins.push("U1.5")
+  problem.chipPinMap["U1.5"] = {
+    pinId: "U1.5",
+    side: "x+",
+    offset: { x: 1, y: 0.6 },
+  }
+  problem.chipPinMap["C3.1"] = {
+    pinId: "C3.1",
+    side: "y+",
+    offset: { x: 0, y: 0.5 },
+  }
+  problem.chipPinMap["C3.2"] = {
+    pinId: "C3.2",
+    side: "y-",
+    offset: { x: 0, y: -0.5 },
+  }
+  problem.pinStrongConnMap = {
+    "U1.4-R1.1": true,
+    "U1.3-R2.1": true,
+    "U1.5-C3.1": true,
+  }
+  problem.netConnMap = {
+    "R1.2-SHARED": true,
+    "R2.2-SHARED": true,
+    "C3.2-SHARED": true,
+  }
+  problem.netMap = { SHARED: { netId: "SHARED" } }
+
+  const groups = findSameSidePassiveGroups(problem)
+
+  expect(groups).toHaveLength(1)
+  expect(groups[0]!.railCarrier).toBeUndefined()
+  expect(groups[0]!.passiveChipIds).toEqual(["R2", "R1", "C3"])
+})

--- a/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
+++ b/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "bun:test"
 import { LayoutPipelineSolver } from "lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver"
 import { findSameSidePassiveGroups } from "lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups"
+import type { Placement } from "lib/types/OutputLayout"
 import type { InputProblem } from "lib/types/InputProblem"
-import { rotatePinOffset } from "lib/utils/rotatePinOffset"
+import { getRotatedSize, rotatePinOffset } from "lib/utils/rotatePinOffset"
 import si7021Input from "../../pages/repros/repro-si7021/si7021-matchpack-input.json"
 import commonNodeInput from "../assets/repro-core-repro70-common-node-placement.input.json"
 
@@ -14,6 +15,7 @@ const makeRailCarrierProblem = (
     multipleRailPins?: boolean
     fixedCarrier?: boolean
     fixedPassive?: boolean
+    fixedMain?: boolean
   } = {},
 ): InputProblem => {
   const main = opts.customIds ? "sensor_controller" : "U1"
@@ -34,6 +36,7 @@ const makeRailCarrierProblem = (
         pins: [`${main}.1`, `${main}.2`, `${main}.3`, `${main}.4`],
         size: { x: 1.2, y: 0.8 },
         availableRotations: [0, 90, 180, 270],
+        ...(opts.fixedMain && { fixedPosition: { x: 0, y: 0 } }),
       },
       [upperPassive]: {
         chipId: upperPassive,
@@ -334,6 +337,185 @@ const makeMultiPassiveRailCarrierProblem = (
   }
 }
 
+const makeMirroredRailCarrierProblem = (): InputProblem => {
+  const problem = makeRailCarrierProblem()
+  problem.chipMap.A = {
+    chipId: "A",
+    pins: ["A.1", "A.2", "A.3", "A.4"],
+    size: { x: 1.2, y: 1.2 },
+    availableRotations: [0, 90, 180, 270],
+  }
+  problem.chipMap.B = {
+    chipId: "B",
+    pins: ["B.1", "B.2", "B.3", "B.4"],
+    size: { x: 1.2, y: 1.2 },
+    availableRotations: [0, 90, 180, 270],
+  }
+  delete problem.chipMap.U1
+  delete problem.chipMap.SJ1
+  problem.chipMap.R3 = {
+    chipId: "R3",
+    pins: ["R3.1", "R3.2"],
+    size: { x: 0.5, y: 1 },
+    availableRotations: [0, 90, 180, 270],
+    isResistor: true,
+  }
+  problem.chipPinMap = {
+    "A.1": { pinId: "A.1", side: "x+", offset: { x: 0.6, y: -0.3 } },
+    "A.2": { pinId: "A.2", side: "x+", offset: { x: 0.6, y: 0 } },
+    "A.3": { pinId: "A.3", side: "y+", offset: { x: 0, y: 0.6 } },
+    "A.4": { pinId: "A.4", side: "x+", offset: { x: 0.6, y: 0.3 } },
+    "B.1": { pinId: "B.1", side: "x-", offset: { x: -0.6, y: -0.3 } },
+    "B.2": { pinId: "B.2", side: "x-", offset: { x: -0.6, y: 0 } },
+    "B.3": { pinId: "B.3", side: "y+", offset: { x: 0, y: 0.6 } },
+    "B.4": { pinId: "B.4", side: "x-", offset: { x: -0.6, y: 0.3 } },
+    "R1.1": { pinId: "R1.1", side: "y+", offset: { x: 0, y: 0.5 } },
+    "R1.2": { pinId: "R1.2", side: "y-", offset: { x: 0, y: -0.5 } },
+    "R2.1": { pinId: "R2.1", side: "y+", offset: { x: 0, y: 0.5 } },
+    "R2.2": { pinId: "R2.2", side: "y-", offset: { x: 0, y: -0.5 } },
+    "R3.1": { pinId: "R3.1", side: "y+", offset: { x: 0, y: 0.5 } },
+    "R3.2": { pinId: "R3.2", side: "y-", offset: { x: 0, y: -0.5 } },
+  }
+  problem.netMap = {
+    A_RAIL: { netId: "A_RAIL" },
+    B_RAIL: { netId: "B_RAIL" },
+  }
+  problem.pinStrongConnMap = {
+    "A.1-R1.1": true,
+    "A.2-R2.1": true,
+    "A.4-R3.1": true,
+    "R1.2-B.1": true,
+    "R2.2-B.2": true,
+    "R3.2-B.4": true,
+  }
+  problem.netConnMap = {
+    "A.3-A_RAIL": true,
+    "B.3-B_RAIL": true,
+  }
+  return problem
+}
+
+const makeDenseRailCarrierGapProblem = (): InputProblem => {
+  const problem = makeRailCarrierProblem()
+  problem.chipGap = 0.5
+  problem.chipPinMap["U1.3"] = {
+    pinId: "U1.3",
+    side: "x+",
+    offset: { x: 1, y: -0.025 },
+  }
+  problem.chipPinMap["U1.4"] = {
+    pinId: "U1.4",
+    side: "x+",
+    offset: { x: 1, y: 0.025 },
+  }
+  return problem
+}
+
+const makeRotatedPackedMainRailCarrierProblem = (): InputProblem => {
+  const passiveIds = ["R1", "R2", "R3", "R4"]
+  const chipMap: InputProblem["chipMap"] = {
+    A: {
+      chipId: "A",
+      pins: ["A.1", "A.2", "A.3", "A.4"],
+      size: { x: 0.8, y: 2.4 },
+      availableRotations: [0, 90, 180, 270],
+    },
+    B: {
+      chipId: "B",
+      pins: ["B.1", "B.2", "B.3", "B.4", "B.RAIL"],
+      size: { x: 0.8, y: 2.4 },
+      availableRotations: [0, 90],
+    },
+  }
+  for (const passiveId of passiveIds) {
+    chipMap[passiveId] = {
+      chipId: passiveId,
+      pins: [`${passiveId}.1`, `${passiveId}.2`],
+      size: { x: 0.5, y: 1 },
+      availableRotations: [0, 90, 180, 270],
+      isResistor: true,
+    }
+  }
+
+  const chipPinMap: InputProblem["chipPinMap"] = {
+    "B.RAIL": { pinId: "B.RAIL", side: "y+", offset: { x: 0, y: 1.2 } },
+  }
+  for (const [index, pinId] of ["A.1", "A.2", "A.3", "A.4"].entries()) {
+    chipPinMap[pinId] = {
+      pinId,
+      side: "y+",
+      offset: { x: (index - 1.5) * 0.2, y: 1.2 },
+    }
+  }
+  for (const [index, pinId] of ["B.1", "B.2", "B.3", "B.4"].entries()) {
+    chipPinMap[pinId] = {
+      pinId,
+      side: "x-",
+      offset: { x: -0.4, y: (index - 1.5) * 0.3 },
+    }
+  }
+  for (const passiveId of passiveIds) {
+    chipPinMap[`${passiveId}.1`] = {
+      pinId: `${passiveId}.1`,
+      side: "y+",
+      offset: { x: 0, y: 0.5 },
+    }
+    chipPinMap[`${passiveId}.2`] = {
+      pinId: `${passiveId}.2`,
+      side: "y-",
+      offset: { x: 0, y: -0.5 },
+    }
+  }
+
+  return {
+    chipMap,
+    chipPinMap,
+    netMap: { RAIL: { netId: "RAIL" } },
+    pinStrongConnMap: Object.fromEntries(
+      passiveIds.flatMap((passiveId, index) => [
+        [`A.${index + 1}-${passiveId}.1`, true],
+        [`${passiveId}.2-B.${index + 1}`, true],
+      ]),
+    ),
+    netConnMap: { "B.RAIL-RAIL": true },
+    chipGap: 0.4,
+    partitionGap: 1.2,
+  }
+}
+
+type Bounds = { minX: number; minY: number; maxX: number; maxY: number }
+
+const getChipBounds = (
+  inputProblem: InputProblem,
+  chipId: string,
+  placement: Placement,
+): Bounds => {
+  const chip = inputProblem.chipMap[chipId]!
+  const size = getRotatedSize(chip.size, placement.ccwRotationDegrees)
+  const points = [
+    { x: placement.x - size.x / 2, y: placement.y - size.y / 2 },
+    { x: placement.x + size.x / 2, y: placement.y + size.y / 2 },
+  ]
+  for (const pinId of chip.pins) {
+    const pin = inputProblem.chipPinMap[pinId]
+    if (!pin) continue
+    const offset = rotatePinOffset(pin.offset, placement.ccwRotationDegrees)
+    points.push({ x: placement.x + offset.x, y: placement.y + offset.y })
+  }
+  return {
+    minX: Math.min(...points.map((point) => point.x)),
+    minY: Math.min(...points.map((point) => point.y)),
+    maxX: Math.max(...points.map((point) => point.x)),
+    maxY: Math.max(...points.map((point) => point.y)),
+  }
+}
+
+const getBoundsDistance = (a: Bounds, b: Bounds): number => {
+  const dx = Math.max(0, a.minX - b.maxX, b.minX - a.maxX)
+  const dy = Math.max(0, a.minY - b.maxY, b.minY - a.maxY)
+  return Math.hypot(dx, dy)
+}
+
 const getStrongEdgeMetrics = (inputProblem: InputProblem) => {
   const solver = new LayoutPipelineSolver(inputProblem)
   solver.solve()
@@ -427,6 +609,52 @@ test("detects five-passive rail-carrier topology by exact carrier pin roles", ()
   expect(groups).toHaveLength(1)
   expect(groups[0]!.railCarrier?.carrierChipId).toBe("Jwide")
   expect(groups[0]!.passiveChipIds).toEqual(["R1", "R2", "R3", "R4", "R5"])
+})
+
+test("declines symmetric mirrored rail-carrier topology", () => {
+  const groups = findSameSidePassiveGroups(makeMirroredRailCarrierProblem())
+
+  expect(groups).toHaveLength(0)
+})
+
+test("keeps dense rail-carrier passives at least chipGap apart", () => {
+  const inputProblem = makeDenseRailCarrierGapProblem()
+  const solver = new LayoutPipelineSolver(inputProblem)
+  solver.solve()
+  const layout = solver.getOutputLayout()
+  const r1Bounds = getChipBounds(inputProblem, "R1", layout.chipPlacements.R1!)
+  const r2Bounds = getChipBounds(inputProblem, "R2", layout.chipPlacements.R2!)
+
+  expect(
+    solver.packInnerPartitionsSolver?.completedSolvers[0]?.constructor.name,
+  ).toBe("ParallelAlignedPassiveSolver")
+  expect(getBoundsDistance(r1Bounds, r2Bounds)).toBeGreaterThanOrEqual(
+    inputProblem.chipGap - 1e-6,
+  )
+})
+
+test("reflows rail-carrier groups using the actual packed main-chip rotation", () => {
+  const inputProblem = makeRotatedPackedMainRailCarrierProblem()
+  const detectedGroups = findSameSidePassiveGroups(inputProblem)
+  const solver = new LayoutPipelineSolver(inputProblem)
+  solver.solve()
+  const layout = solver.getOutputLayout()
+  const mainPlacement = layout.chipPlacements.A!
+  const mainBounds = getChipBounds(inputProblem, "A", mainPlacement)
+
+  expect(detectedGroups).toHaveLength(1)
+  expect(detectedGroups[0]!.side).toBe("y+")
+  expect(mainPlacement.ccwRotationDegrees).toBe(90)
+  for (const passiveChipId of ["R1", "R2", "R3", "R4"]) {
+    const passiveBounds = getChipBounds(
+      inputProblem,
+      passiveChipId,
+      layout.chipPlacements[passiveChipId]!,
+    )
+    expect(passiveBounds.maxX).toBeLessThanOrEqual(
+      mainBounds.minX - inputProblem.chipGap + 1e-6,
+    )
+  }
 })
 
 test("declines rail-carrier topology for diode-like or untyped leaves", () => {

--- a/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
+++ b/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "bun:test"
 import { LayoutPipelineSolver } from "lib/solvers/LayoutPipelineSolver/LayoutPipelineSolver"
+import { ParallelAlignedPassiveSolver } from "lib/solvers/PackInnerPartitionsSolver/ParallelAlignedPassiveSolver"
 import { findSameSidePassiveGroups } from "lib/solvers/PackInnerPartitionsSolver/findSameSidePassiveGroups"
-import type { Placement } from "lib/types/OutputLayout"
-import type { InputProblem } from "lib/types/InputProblem"
+import type { OutputLayout, Placement } from "lib/types/OutputLayout"
+import type { ChipPin, InputProblem } from "lib/types/InputProblem"
 import { getRotatedSize, rotatePinOffset } from "lib/utils/rotatePinOffset"
 import si7021Input from "../../pages/repros/repro-si7021/si7021-matchpack-input.json"
 import commonNodeInput from "../assets/repro-core-repro70-common-node-placement.input.json"
@@ -516,6 +517,159 @@ const getBoundsDistance = (a: Bounds, b: Bounds): number => {
   return Math.hypot(dx, dy)
 }
 
+const getConnectedPinsByPinId = (
+  inputProblem: InputProblem,
+): Record<string, ChipPin[]> => {
+  const connectedPinsByPinId: Record<string, ChipPin[]> = {}
+  for (const [connKey, connected] of Object.entries(
+    inputProblem.pinStrongConnMap,
+  )) {
+    if (!connected) continue
+    const [a, b] = connKey.split("-")
+    const pinA = a && inputProblem.chipPinMap[a]
+    const pinB = b && inputProblem.chipPinMap[b]
+    if (!a || !b || !pinA || !pinB) continue
+    connectedPinsByPinId[a] = [...(connectedPinsByPinId[a] ?? []), pinB]
+    connectedPinsByPinId[b] = [...(connectedPinsByPinId[b] ?? []), pinA]
+  }
+  return connectedPinsByPinId
+}
+
+const makeRailCarrierPackedLayout = (): OutputLayout => ({
+  chipPlacements: {
+    U1: { x: 0, y: 0, ccwRotationDegrees: 0 },
+    R1: { x: 7, y: 7, ccwRotationDegrees: 0 },
+    R2: { x: 8, y: 7, ccwRotationDegrees: 0 },
+    SJ1: { x: 9, y: 7, ccwRotationDegrees: 0 },
+  },
+  groupPlacements: {},
+})
+
+const alignRailCarrierFromPackedLayout = (
+  inputProblem: InputProblem,
+  baseLayout: OutputLayout,
+): OutputLayout => {
+  const solver = new ParallelAlignedPassiveSolver({
+    partitionInputProblem: inputProblem,
+    pinIdToStronglyConnectedPins: getConnectedPinsByPinId(inputProblem),
+  })
+  return (
+    solver as unknown as {
+      alignPassiveGroups(base: OutputLayout): OutputLayout
+    }
+  ).alignPassiveGroups(baseLayout)
+}
+
+const withFixedObstacle = ({
+  inputProblem,
+  x,
+  y,
+}: {
+  inputProblem: InputProblem
+  x: number
+  y: number
+}): InputProblem => {
+  const next = structuredClone(inputProblem)
+  next.chipMap.OBS = {
+    chipId: "OBS",
+    pins: [],
+    size: { x: 0.2, y: 0.2 },
+    availableRotations: [0],
+    fixedPosition: { x, y },
+  }
+  return next
+}
+
+const makeRailCarrierObstacleProblem = ({
+  targetChipId,
+  clearance,
+  chipGap = 0.5,
+}: {
+  targetChipId: "R2" | "SJ1"
+  clearance: number
+  chipGap?: number
+}): {
+  inputProblem: InputProblem
+  baseLayout: OutputLayout
+  unobstructedLayout: OutputLayout
+} => {
+  const inputProblem = makeDenseRailCarrierGapProblem()
+  inputProblem.chipGap = chipGap
+  const baseLayout = makeRailCarrierPackedLayout()
+  const unobstructedLayout = alignRailCarrierFromPackedLayout(
+    inputProblem,
+    baseLayout,
+  )
+  const targetBounds = getChipBounds(
+    inputProblem,
+    targetChipId,
+    unobstructedLayout.chipPlacements[targetChipId]!,
+  )
+  const obstacleX = targetBounds.maxX + clearance + 0.1
+  const obstacleY = (targetBounds.minY + targetBounds.maxY) / 2
+
+  return {
+    inputProblem: withFixedObstacle({
+      inputProblem,
+      x: obstacleX,
+      y: obstacleY,
+    }),
+    baseLayout: {
+      chipPlacements: {
+        ...baseLayout.chipPlacements,
+        OBS: { x: obstacleX, y: obstacleY, ccwRotationDegrees: 0 },
+      },
+      groupPlacements: {},
+    },
+    unobstructedLayout,
+  }
+}
+
+const expectPlacementToEqual = (
+  actual: Placement,
+  expected: Placement,
+): void => {
+  expect(actual.x).toBe(expected.x)
+  expect(actual.y).toBe(expected.y)
+  expect(actual.ccwRotationDegrees).toBe(expected.ccwRotationDegrees)
+}
+
+const getDistancesFromMovedGroup = (
+  inputProblem: InputProblem,
+  layout: OutputLayout,
+): Array<{ pair: string; distance: number }> => {
+  const movedChipIds = ["R1", "R2", "SJ1"]
+  const pairs: Array<{ pair: string; distance: number }> = []
+  for (const chipId of movedChipIds) {
+    const chipBounds = getChipBounds(
+      inputProblem,
+      chipId,
+      layout.chipPlacements[chipId]!,
+    )
+    for (const [otherChipId, otherPlacement] of Object.entries(
+      layout.chipPlacements,
+    )) {
+      if (otherChipId === chipId) continue
+      if (
+        movedChipIds.includes(otherChipId) &&
+        movedChipIds.indexOf(otherChipId) < movedChipIds.indexOf(chipId)
+      ) {
+        continue
+      }
+      const otherBounds = getChipBounds(
+        inputProblem,
+        otherChipId,
+        otherPlacement,
+      )
+      pairs.push({
+        pair: `${chipId}-${otherChipId}`,
+        distance: getBoundsDistance(chipBounds, otherBounds),
+      })
+    }
+  }
+  return pairs
+}
+
 const getStrongEdgeMetrics = (inputProblem: InputProblem) => {
   const solver = new LayoutPipelineSolver(inputProblem)
   solver.solve()
@@ -631,6 +785,92 @@ test("keeps dense rail-carrier passives at least chipGap apart", () => {
   expect(getBoundsDistance(r1Bounds, r2Bounds)).toBeGreaterThanOrEqual(
     inputProblem.chipGap - 1e-6,
   )
+})
+
+test("rejects rail-carrier reflow that would violate chipGap to an unrelated obstacle", () => {
+  const { inputProblem, baseLayout, unobstructedLayout } =
+    makeRailCarrierObstacleProblem({
+      targetChipId: "R2",
+      clearance: 0.1,
+    })
+  const obstacleBounds = getChipBounds(
+    inputProblem,
+    "OBS",
+    baseLayout.chipPlacements.OBS!,
+  )
+  const proposedR1Distance = getBoundsDistance(
+    getChipBounds(inputProblem, "R1", unobstructedLayout.chipPlacements.R1!),
+    obstacleBounds,
+  )
+  const proposedR2Distance = getBoundsDistance(
+    getChipBounds(inputProblem, "R2", unobstructedLayout.chipPlacements.R2!),
+    obstacleBounds,
+  )
+
+  expect(proposedR1Distance).toBeGreaterThan(0)
+  expect(proposedR1Distance).toBeLessThan(inputProblem.chipGap)
+  expect(proposedR2Distance).toBeGreaterThan(0)
+  expect(proposedR2Distance).toBeLessThan(inputProblem.chipGap)
+
+  const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
+  for (const chipId of ["R1", "R2", "SJ1"]) {
+    expectPlacementToEqual(
+      layout.chipPlacements[chipId]!,
+      baseLayout.chipPlacements[chipId]!,
+    )
+  }
+})
+
+test("rail-carrier obstacle boundary preserves chipGap semantics", () => {
+  const cases = [
+    { clearance: 0.1, chipGap: 0.5, shouldAccept: false },
+    { clearance: 0.499, chipGap: 0.5, shouldAccept: false },
+    { clearance: 0.5, chipGap: 0.5, shouldAccept: true },
+    { clearance: 0.6, chipGap: 0.5, shouldAccept: true },
+    { clearance: 0.1, chipGap: 0, shouldAccept: true },
+  ]
+
+  for (const testCase of cases) {
+    const { inputProblem, baseLayout, unobstructedLayout } =
+      makeRailCarrierObstacleProblem({
+        targetChipId: "SJ1",
+        clearance: testCase.clearance,
+        chipGap: testCase.chipGap,
+      })
+    const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
+
+    for (const chipId of ["R1", "R2", "SJ1"]) {
+      expectPlacementToEqual(
+        layout.chipPlacements[chipId]!,
+        (testCase.shouldAccept ? unobstructedLayout : baseLayout)
+          .chipPlacements[chipId]!,
+      )
+    }
+  }
+})
+
+test("accepted rail-carrier reflow satisfies chipGap for every moved pair", () => {
+  const { inputProblem, baseLayout } = makeRailCarrierObstacleProblem({
+    targetChipId: "SJ1",
+    clearance: 0.6,
+  })
+  const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
+  const distances = getDistancesFromMovedGroup(inputProblem, layout)
+
+  expect(distances.map((entry) => entry.pair).sort()).toEqual([
+    "R1-OBS",
+    "R1-R2",
+    "R1-SJ1",
+    "R1-U1",
+    "R2-OBS",
+    "R2-SJ1",
+    "R2-U1",
+    "SJ1-OBS",
+    "SJ1-U1",
+  ])
+  for (const { distance } of distances) {
+    expect(distance).toBeGreaterThanOrEqual(inputProblem.chipGap - 1e-6)
+  }
 })
 
 test("reflows rail-carrier groups using the actual packed main-chip rotation", () => {

--- a/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
+++ b/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
@@ -17,6 +17,9 @@ const makeRailCarrierProblem = (
     fixedCarrier?: boolean
     fixedPassive?: boolean
     fixedMain?: boolean
+    branchedMainFacingPin?: boolean
+    branchedCarrierFacingPin?: boolean
+    customNet?: boolean
   } = {},
 ): InputProblem => {
   const main = opts.customIds ? "sensor_controller" : "U1"
@@ -24,6 +27,7 @@ const makeRailCarrierProblem = (
   const lowerPassive = opts.customIds ? "pullup_lower" : "R2"
   const carrierA = opts.customIds ? "selectable_bridge_a" : "SJ1"
   const carrierB = opts.customIds ? "selectable_bridge_b" : "SJ2"
+  const railNet = opts.customNet ? "pullup_bus" : "RAIL"
   const lowerCarrier = opts.differentCarriers ? carrierB : carrierA
   const carrierPins =
     opts.ambiguousCarrierBranch || opts.multipleRailPins
@@ -69,7 +73,9 @@ const makeRailCarrierProblem = (
           availableRotations: [0, 90, 180, 270],
         },
       }),
-      ...(opts.ambiguousCarrierBranch && {
+      ...((opts.ambiguousCarrierBranch ||
+        opts.branchedMainFacingPin ||
+        opts.branchedCarrierFacingPin) && {
         branch_load: {
           chipId: "branch_load",
           pins: ["branch_load.1", "branch_load.2"],
@@ -158,7 +164,9 @@ const makeRailCarrierProblem = (
           offset: { x: 0.3, y: 0 },
         },
       }),
-      ...(opts.ambiguousCarrierBranch && {
+      ...((opts.ambiguousCarrierBranch ||
+        opts.branchedMainFacingPin ||
+        opts.branchedCarrierFacingPin) && {
         "branch_load.1": {
           pinId: "branch_load.1",
           side: "y+",
@@ -172,7 +180,7 @@ const makeRailCarrierProblem = (
       }),
     },
     netMap: {
-      RAIL: { netId: "RAIL" },
+      [railNet]: { netId: railNet },
       ...(opts.multipleRailPins && { OTHER_RAIL: { netId: "OTHER_RAIL" } }),
     },
     pinStrongConnMap: {
@@ -183,10 +191,16 @@ const makeRailCarrierProblem = (
       ...(opts.ambiguousCarrierBranch && {
         [`${carrierA}.4-branch_load.1`]: true,
       }),
+      ...(opts.branchedMainFacingPin && {
+        [`${upperPassive}.1-branch_load.1`]: true,
+      }),
+      ...(opts.branchedCarrierFacingPin && {
+        [`${upperPassive}.2-branch_load.1`]: true,
+      }),
     },
     netConnMap: {
-      [`${carrierA}.2-RAIL`]: true,
-      ...(opts.differentCarriers && { [`${carrierB}.2-RAIL`]: true }),
+      [`${carrierA}.2-${railNet}`]: true,
+      ...(opts.differentCarriers && { [`${carrierB}.2-${railNet}`]: true }),
       ...(opts.multipleRailPins && { [`${carrierA}.4-OTHER_RAIL`]: true }),
     },
     chipGap: 0.4,
@@ -737,12 +751,45 @@ test("lays out SI7021 rail-carrier passives with materially lower off-axis error
 
 test("detects rail-carrier topology with arbitrary component ids", () => {
   const groups = findSameSidePassiveGroups(
-    makeRailCarrierProblem({ customIds: true }),
+    makeRailCarrierProblem({ customIds: true, customNet: true }),
   )
 
   expect(groups).toHaveLength(1)
   expect(groups[0]!.railCarrier?.carrierChipId).toBe("selectable_bridge_a")
   expect(groups[0]!.passiveChipIds).toEqual(["pullup_lower", "pullup_upper"])
+})
+
+test("declines rail-carrier topology when a resistor main-facing pin is branched", () => {
+  expect(
+    findSameSidePassiveGroups(
+      makeRailCarrierProblem({ branchedMainFacingPin: true }),
+    ),
+  ).toHaveLength(0)
+  expect(
+    findSameSidePassiveGroups(
+      makeRailCarrierProblem({
+        branchedMainFacingPin: true,
+        customIds: true,
+      }),
+    ),
+  ).toHaveLength(0)
+
+  const renamedOrderVariant = makeRailCarrierProblem({
+    branchedMainFacingPin: true,
+    customIds: true,
+  })
+  renamedOrderVariant.pinStrongConnMap = Object.fromEntries(
+    Object.entries(renamedOrderVariant.pinStrongConnMap).reverse(),
+  )
+  expect(findSameSidePassiveGroups(renamedOrderVariant)).toHaveLength(0)
+})
+
+test("declines rail-carrier topology when a resistor carrier-facing pin is branched", () => {
+  expect(
+    findSameSidePassiveGroups(
+      makeRailCarrierProblem({ branchedCarrierFacingPin: true }),
+    ),
+  ).toHaveLength(0)
 })
 
 test("detects four-passive rail-carrier topology without a pin-count ceiling", () => {

--- a/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
+++ b/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
@@ -433,6 +433,29 @@ const makeDenseRailCarrierGapProblem = (): InputProblem => {
   return problem
 }
 
+const getRailCarrierGroups = (inputProblem: InputProblem) =>
+  findSameSidePassiveGroups(inputProblem).filter((group) => group.railCarrier)
+
+const replaceStrongConnection = (
+  inputProblem: InputProblem,
+  from: `${string}-${string}`,
+  to: `${string}-${string}`,
+): void => {
+  delete inputProblem.pinStrongConnMap[from]
+  inputProblem.pinStrongConnMap[to] = true
+}
+
+const makeRailCarrierContractProblem = (
+  mutate?: (inputProblem: InputProblem) => void,
+): InputProblem => {
+  const inputProblem = makeMultiPassiveRailCarrierProblem({ passiveCount: 3 })
+  mutate?.(inputProblem)
+  return inputProblem
+}
+
+const reorderRecord = <T>(record: Record<string, T>): Record<string, T> =>
+  Object.fromEntries(Object.entries(record).reverse())
+
 const makeRotatedPackedMainRailCarrierProblem = (): InputProblem => {
   const passiveIds = ["R1", "R2", "R3", "R4"]
   const chipMap: InputProblem["chipMap"] = {
@@ -868,6 +891,299 @@ test("declines fixed-main rail-carrier topology when a resistor pin is branched"
       }),
     ),
   ).toHaveLength(0)
+})
+
+test("enforces rail-carrier identity and cardinality invariants", () => {
+  const cases: Array<{
+    name: string
+    mutate: (inputProblem: InputProblem) => void
+    expectedRailGroups: number
+  }> = [
+    {
+      name: "duplicate main pin",
+      mutate: (inputProblem) => {
+        replaceStrongConnection(inputProblem, "Uwide.2-R2.1", "Uwide.1-R2.1")
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "all resistors share one main pin",
+      mutate: (inputProblem) => {
+        replaceStrongConnection(inputProblem, "Uwide.2-R2.1", "Uwide.1-R2.1")
+        replaceStrongConnection(inputProblem, "Uwide.3-R3.1", "Uwide.1-R3.1")
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "duplicate carrier pin",
+      mutate: (inputProblem) => {
+        replaceStrongConnection(inputProblem, "R2.2-Jwide.2", "R2.2-Jwide.1")
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "all resistors share one carrier pin",
+      mutate: (inputProblem) => {
+        replaceStrongConnection(inputProblem, "R2.2-Jwide.2", "R2.2-Jwide.1")
+        replaceStrongConnection(inputProblem, "R3.2-Jwide.3", "R3.2-Jwide.1")
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "different main chip",
+      mutate: (inputProblem) => {
+        inputProblem.chipMap.Uother = {
+          chipId: "Uother",
+          pins: ["Uother.1", "Uother.2", "Uother.3", "Uother.4"],
+          size: { x: 1.6, y: 1.6 },
+          availableRotations: [0, 90, 180, 270],
+        }
+        inputProblem.chipPinMap["Uother.1"] = {
+          pinId: "Uother.1",
+          side: "x+",
+          offset: { x: 1, y: 0 },
+        }
+        replaceStrongConnection(inputProblem, "Uwide.3-R3.1", "Uother.1-R3.1")
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "different carrier chip",
+      mutate: (inputProblem) => {
+        inputProblem.chipMap.Jother = {
+          chipId: "Jother",
+          pins: ["Jother.1", "Jother.RAIL"],
+          size: { x: 0.8, y: 0.8 },
+          availableRotations: [0, 90, 180, 270],
+        }
+        inputProblem.chipPinMap["Jother.1"] = {
+          pinId: "Jother.1",
+          side: "x-",
+          offset: { x: -0.4, y: 0 },
+        }
+        inputProblem.chipPinMap["Jother.RAIL"] = {
+          pinId: "Jother.RAIL",
+          side: "y+",
+          offset: { x: 0, y: 0.4 },
+        }
+        inputProblem.netConnMap["Jother.RAIL-RAIL"] = true
+        replaceStrongConnection(inputProblem, "R3.2-Jwide.3", "R3.2-Jother.1")
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "same main and carrier chip",
+      mutate: (inputProblem) => {
+        replaceStrongConnection(inputProblem, "R1.2-Jwide.1", "R1.2-Uwide.4")
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "main-facing branch",
+      mutate: (inputProblem) => {
+        inputProblem.chipMap.TP1 = {
+          chipId: "TP1",
+          pins: ["TP1.1"],
+          size: { x: 0.2, y: 0.2 },
+          availableRotations: [0],
+        }
+        inputProblem.chipPinMap["TP1.1"] = {
+          pinId: "TP1.1",
+          side: "x+",
+          offset: { x: 0.1, y: 0 },
+        }
+        inputProblem.pinStrongConnMap["R1.1-TP1.1"] = true
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "carrier-facing branch",
+      mutate: (inputProblem) => {
+        inputProblem.chipMap.TP1 = {
+          chipId: "TP1",
+          pins: ["TP1.1"],
+          size: { x: 0.2, y: 0.2 },
+          availableRotations: [0],
+        }
+        inputProblem.chipPinMap["TP1.1"] = {
+          pinId: "TP1.1",
+          side: "x+",
+          offset: { x: 0.1, y: 0 },
+        }
+        inputProblem.pinStrongConnMap["R1.2-TP1.1"] = true
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "carrier claimed pin branch",
+      mutate: (inputProblem) => {
+        inputProblem.chipMap.TP1 = {
+          chipId: "TP1",
+          pins: ["TP1.1"],
+          size: { x: 0.2, y: 0.2 },
+          availableRotations: [0],
+        }
+        inputProblem.chipPinMap["TP1.1"] = {
+          pinId: "TP1.1",
+          side: "x+",
+          offset: { x: 0.1, y: 0 },
+        }
+        inputProblem.pinStrongConnMap["Jwide.1-TP1.1"] = true
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "extra unexplained carrier pin",
+      mutate: (inputProblem) => {
+        inputProblem.chipMap.Jwide!.pins.push("Jwide.NC")
+        inputProblem.chipPinMap["Jwide.NC"] = {
+          pinId: "Jwide.NC",
+          side: "y-",
+          offset: { x: 0, y: -0.4 },
+        }
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "zero rail pins",
+      mutate: (inputProblem) => {
+        inputProblem.netConnMap = {}
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "multiple rail pins",
+      mutate: (inputProblem) => {
+        inputProblem.chipMap.Jwide!.pins.push("Jwide.RAIL2")
+        inputProblem.chipPinMap["Jwide.RAIL2"] = {
+          pinId: "Jwide.RAIL2",
+          side: "y+",
+          offset: { x: 0.2, y: 0.4 },
+        }
+        inputProblem.netMap.RAIL2 = { netId: "RAIL2" }
+        inputProblem.netConnMap["Jwide.RAIL2-RAIL2"] = true
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "rail pin with ambiguous net membership",
+      mutate: (inputProblem) => {
+        inputProblem.netMap.OTHER = { netId: "OTHER" }
+        inputProblem.netConnMap["Jwide.RAIL-OTHER"] = true
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "partial carrier accounting",
+      mutate: (inputProblem) => {
+        delete inputProblem.pinStrongConnMap["R3.2-Jwide.3"]
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "mixed main-chip side",
+      mutate: (inputProblem) => {
+        inputProblem.chipPinMap["Uwide.3"] = {
+          pinId: "Uwide.3",
+          side: "x-",
+          offset: { x: -1, y: 0.2 },
+        }
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "same-side distinct pins with identical edge coordinate",
+      mutate: (inputProblem) => {
+        inputProblem.chipPinMap["Uwide.2"] = {
+          ...inputProblem.chipPinMap["Uwide.2"]!,
+          offset: { ...inputProblem.chipPinMap["Uwide.1"]!.offset },
+        }
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "fixed resistor",
+      mutate: (inputProblem) => {
+        inputProblem.chipMap.R1!.fixedPosition = { x: 2, y: 1 }
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "fixed carrier",
+      mutate: (inputProblem) => {
+        inputProblem.chipMap.Jwide!.fixedPosition = { x: 3, y: 0 }
+      },
+      expectedRailGroups: 0,
+    },
+    {
+      name: "fixed main remains valid",
+      mutate: (inputProblem) => {
+        inputProblem.chipMap.Uwide!.fixedPosition = { x: 0, y: 0 }
+      },
+      expectedRailGroups: 1,
+    },
+    {
+      name: "reordered maps remain valid",
+      mutate: (inputProblem) => {
+        inputProblem.chipMap = reorderRecord(inputProblem.chipMap)
+        inputProblem.chipPinMap = reorderRecord(inputProblem.chipPinMap)
+        inputProblem.pinStrongConnMap = reorderRecord(
+          inputProblem.pinStrongConnMap,
+        )
+        inputProblem.netConnMap = reorderRecord(inputProblem.netConnMap)
+      },
+      expectedRailGroups: 1,
+    },
+  ]
+
+  for (const testCase of cases) {
+    const groups = getRailCarrierGroups(
+      makeRailCarrierContractProblem(testCase.mutate),
+    )
+    expect(groups, testCase.name).toHaveLength(testCase.expectedRailGroups)
+    if (testCase.expectedRailGroups === 1) {
+      expect(groups[0]!.passiveChipIds, testCase.name).toEqual([
+        "R1",
+        "R2",
+        "R3",
+      ])
+    }
+  }
+})
+
+test("declines mirrored or overlapping rail-carrier membership ambiguity", () => {
+  expect(getRailCarrierGroups(makeMirroredRailCarrierProblem())).toHaveLength(0)
+
+  const overlappingCarrierProblem = makeRailCarrierContractProblem(
+    (inputProblem) => {
+      inputProblem.chipMap.Jother = {
+        chipId: "Jother",
+        pins: ["Jother.1", "Jother.2", "Jother.RAIL"],
+        size: { x: 0.8, y: 0.8 },
+        availableRotations: [0, 90, 180, 270],
+      }
+      inputProblem.chipPinMap["Jother.1"] = {
+        pinId: "Jother.1",
+        side: "x-",
+        offset: { x: -0.4, y: -0.1 },
+      }
+      inputProblem.chipPinMap["Jother.2"] = {
+        pinId: "Jother.2",
+        side: "x-",
+        offset: { x: -0.4, y: 0.1 },
+      }
+      inputProblem.chipPinMap["Jother.RAIL"] = {
+        pinId: "Jother.RAIL",
+        side: "y+",
+        offset: { x: 0, y: 0.4 },
+      }
+      inputProblem.netConnMap["Jother.RAIL-RAIL"] = true
+      inputProblem.pinStrongConnMap["R2.2-Jother.1"] = true
+      replaceStrongConnection(inputProblem, "R3.2-Jwide.3", "R3.2-Jother.2")
+    },
+  )
+
+  expect(getRailCarrierGroups(overlappingCarrierProblem)).toHaveLength(0)
 })
 
 test("detects four-passive rail-carrier topology without a pin-count ceiling", () => {

--- a/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
+++ b/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
@@ -40,6 +40,7 @@ const makeRailCarrierProblem = (
         pins: [`${upperPassive}.1`, `${upperPassive}.2`],
         size: { x: 0.5, y: 1 },
         availableRotations: [0, 90, 180, 270],
+        isResistor: true,
         ...(opts.fixedPassive && { fixedPosition: { x: 2, y: 1 } }),
       },
       [lowerPassive]: {
@@ -47,6 +48,7 @@ const makeRailCarrierProblem = (
         pins: [`${lowerPassive}.1`, `${lowerPassive}.2`],
         size: { x: 0.5, y: 1 },
         availableRotations: [0, 90, 180, 270],
+        isResistor: true,
       },
       [carrierA]: {
         chipId: carrierA,
@@ -188,6 +190,150 @@ const makeRailCarrierProblem = (
   }
 }
 
+const makeMultiPassiveRailCarrierProblem = (
+  opts: {
+    passiveCount?: number
+    extraBranch?: boolean
+    multipleRailPins?: boolean
+    extraCarrierPin?: boolean
+    diodeLikeFirstPassive?: boolean
+    untypedFirstPassive?: boolean
+    transistorLikeFirstPassive?: boolean
+    largeCarrierLike?: boolean
+  } = {},
+): InputProblem => {
+  const passiveCount = opts.passiveCount ?? 4
+  const mainPins = Array.from({ length: Math.max(passiveCount, 4) }, (_, i) => {
+    return `Uwide.${i + 1}`
+  })
+  const passiveIds = Array.from({ length: passiveCount }, (_, i) => {
+    if (i === 0 && opts.diodeLikeFirstPassive) return "Dprotect"
+    if (i === 0 && opts.untypedFirstPassive) return "leaf"
+    if (i === 0 && opts.transistorLikeFirstPassive) return "Q1"
+    return `R${i + 1}`
+  })
+  const carrierPassivePins = passiveIds.map((_, i) => `Jwide.${i + 1}`)
+  const railPins = opts.multipleRailPins
+    ? ["Jwide.RAIL1", "Jwide.RAIL2"]
+    : ["Jwide.RAIL"]
+  const extraCarrierPins = [
+    ...(opts.extraBranch ? ["Jwide.BRANCH"] : []),
+    ...(opts.extraCarrierPin ? ["Jwide.NC"] : []),
+    ...(opts.largeCarrierLike
+      ? Array.from({ length: 12 }, (_, i) => `Jwide.EXTRA${i + 1}`)
+      : []),
+  ]
+  const carrierPins = [...carrierPassivePins, ...railPins, ...extraCarrierPins]
+  const chipMap: InputProblem["chipMap"] = {
+    Uwide: {
+      chipId: "Uwide",
+      pins: mainPins,
+      size: { x: 1.6, y: 1.6 },
+      availableRotations: [0, 90, 180, 270],
+    },
+    Jwide: {
+      chipId: "Jwide",
+      pins: carrierPins,
+      size: { x: 0.8, y: 0.8 },
+      availableRotations: [0, 90, 180, 270],
+    },
+  }
+  const chipPinMap: InputProblem["chipPinMap"] = {}
+  const pinStrongConnMap: InputProblem["pinStrongConnMap"] = {}
+  const netConnMap: InputProblem["netConnMap"] = {}
+
+  for (const [index, pinId] of mainPins.entries()) {
+    chipPinMap[pinId] = {
+      pinId,
+      side: "x+",
+      offset: { x: 1, y: index * 0.35 - passiveCount * 0.175 },
+    }
+  }
+  for (const [index, passiveId] of passiveIds.entries()) {
+    const firstPassiveHasUnsupportedType =
+      index === 0 &&
+      (opts.diodeLikeFirstPassive ||
+        opts.untypedFirstPassive ||
+        opts.transistorLikeFirstPassive)
+    const passivePins =
+      opts.transistorLikeFirstPassive && index === 0
+        ? [`${passiveId}.1`, `${passiveId}.2`, `${passiveId}.3`]
+        : [`${passiveId}.1`, `${passiveId}.2`]
+    chipMap[passiveId] = {
+      chipId: passiveId,
+      pins: passivePins,
+      size: { x: 0.5, y: 1 },
+      availableRotations: [0, 90, 180, 270],
+      ...(!firstPassiveHasUnsupportedType && { isResistor: true }),
+    }
+    chipPinMap[`${passiveId}.1`] = {
+      pinId: `${passiveId}.1`,
+      side: "y+",
+      offset: { x: 0, y: 0.5 },
+    }
+    chipPinMap[`${passiveId}.2`] = {
+      pinId: `${passiveId}.2`,
+      side: "y-",
+      offset: { x: 0, y: -0.5 },
+    }
+    if (passivePins.length === 3) {
+      chipPinMap[`${passiveId}.3`] = {
+        pinId: `${passiveId}.3`,
+        side: "x+",
+        offset: { x: 0.25, y: 0 },
+      }
+    }
+    pinStrongConnMap[`Uwide.${index + 1}-${passiveId}.1`] = true
+    pinStrongConnMap[`${passiveId}.2-Jwide.${index + 1}`] = true
+  }
+
+  for (const [index, pinId] of carrierPins.entries()) {
+    chipPinMap[pinId] = {
+      pinId,
+      side: pinId.includes("RAIL") ? "y+" : "x-",
+      offset: {
+        x: pinId.includes("RAIL") ? 0 : -0.4,
+        y: index * 0.2 - carrierPins.length * 0.1,
+      },
+    }
+  }
+  for (const [index, railPinId] of railPins.entries()) {
+    netConnMap[`${railPinId}-RAIL${index || ""}`] = true
+  }
+  if (opts.extraBranch) {
+    chipMap.branch_load = {
+      chipId: "branch_load",
+      pins: ["branch_load.1", "branch_load.2"],
+      size: { x: 0.5, y: 1 },
+      availableRotations: [0, 90, 180, 270],
+    }
+    chipPinMap["branch_load.1"] = {
+      pinId: "branch_load.1",
+      side: "y+",
+      offset: { x: 0, y: 0.5 },
+    }
+    chipPinMap["branch_load.2"] = {
+      pinId: "branch_load.2",
+      side: "y-",
+      offset: { x: 0, y: -0.5 },
+    }
+    pinStrongConnMap["Jwide.BRANCH-branch_load.1"] = true
+  }
+
+  return {
+    chipMap,
+    chipPinMap,
+    netMap: {
+      RAIL: { netId: "RAIL" },
+      ...(opts.multipleRailPins && { RAIL1: { netId: "RAIL1" } }),
+    },
+    pinStrongConnMap,
+    netConnMap,
+    chipGap: 0.4,
+    partitionGap: 1.2,
+  }
+}
+
 const getStrongEdgeMetrics = (inputProblem: InputProblem) => {
   const solver = new LayoutPipelineSolver(inputProblem)
   solver.solve()
@@ -263,6 +409,47 @@ test("detects rail-carrier topology with arbitrary component ids", () => {
   expect(groups[0]!.passiveChipIds).toEqual(["pullup_lower", "pullup_upper"])
 })
 
+test("detects four-passive rail-carrier topology without a pin-count ceiling", () => {
+  const groups = findSameSidePassiveGroups(
+    makeMultiPassiveRailCarrierProblem({ passiveCount: 4 }),
+  )
+
+  expect(groups).toHaveLength(1)
+  expect(groups[0]!.railCarrier?.carrierChipId).toBe("Jwide")
+  expect(groups[0]!.passiveChipIds).toEqual(["R1", "R2", "R3", "R4"])
+})
+
+test("detects five-passive rail-carrier topology by exact carrier pin roles", () => {
+  const groups = findSameSidePassiveGroups(
+    makeMultiPassiveRailCarrierProblem({ passiveCount: 5 }),
+  )
+
+  expect(groups).toHaveLength(1)
+  expect(groups[0]!.railCarrier?.carrierChipId).toBe("Jwide")
+  expect(groups[0]!.passiveChipIds).toEqual(["R1", "R2", "R3", "R4", "R5"])
+})
+
+test("declines rail-carrier topology for diode-like or untyped leaves", () => {
+  expect(
+    findSameSidePassiveGroups(
+      makeMultiPassiveRailCarrierProblem({ diodeLikeFirstPassive: true }),
+    ),
+  ).toHaveLength(0)
+  expect(
+    findSameSidePassiveGroups(
+      makeMultiPassiveRailCarrierProblem({ untypedFirstPassive: true }),
+    ),
+  ).toHaveLength(0)
+})
+
+test("declines rail-carrier topology for non-two-pin passive leaves", () => {
+  expect(
+    findSameSidePassiveGroups(
+      makeMultiPassiveRailCarrierProblem({ transistorLikeFirstPassive: true }),
+    ),
+  ).toHaveLength(0)
+})
+
 test("declines same-side passives attached to unrelated downstream parts", () => {
   expect(
     findSameSidePassiveGroups(
@@ -283,6 +470,32 @@ test("declines a shared carrier with multiple possible rail pins", () => {
   expect(
     findSameSidePassiveGroups(
       makeRailCarrierProblem({ multipleRailPins: true }),
+    ),
+  ).toHaveLength(0)
+})
+
+test("declines larger carriers with unexplained pins or branches", () => {
+  expect(
+    findSameSidePassiveGroups(
+      makeMultiPassiveRailCarrierProblem({ extraBranch: true }),
+    ),
+  ).toHaveLength(0)
+  expect(
+    findSameSidePassiveGroups(
+      makeMultiPassiveRailCarrierProblem({ extraCarrierPin: true }),
+    ),
+  ).toHaveLength(0)
+  expect(
+    findSameSidePassiveGroups(
+      makeMultiPassiveRailCarrierProblem({ largeCarrierLike: true }),
+    ),
+  ).toHaveLength(0)
+})
+
+test("declines four-passive carrier with multiple possible rail pins", () => {
+  expect(
+    findSameSidePassiveGroups(
+      makeMultiPassiveRailCarrierProblem({ multipleRailPins: true }),
     ),
   ).toHaveLength(0)
 })

--- a/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
+++ b/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
@@ -669,6 +669,115 @@ const makeRailCarrierObstacleProblem = ({
   }
 }
 
+const makeRailCarrierRotationRetryProblem = ({
+  rotations = [0, 90],
+  carrierSize = { x: 0.3, y: 1.2 },
+  obstaclePosition = { x: 3.925001, y: -0.25 },
+}: {
+  rotations?: Array<0 | 90 | 180 | 270>
+  carrierSize?: { x: number; y: number }
+  obstaclePosition?: { x: number; y: number } | null
+} = {}): {
+  inputProblem: InputProblem
+  baseLayout: OutputLayout
+} => {
+  const inputProblem: InputProblem = {
+    chipMap: {
+      U1: {
+        chipId: "U1",
+        pins: ["U1.1", "U1.2", "U1.3", "U1.4"],
+        size: { x: 1.2, y: 0.8 },
+        availableRotations: [0],
+        fixedPosition: { x: 0, y: 0 },
+      },
+      R1: {
+        chipId: "R1",
+        pins: ["R1.1", "R1.2"],
+        size: { x: 0.5, y: 1 },
+        availableRotations: [0],
+        isResistor: true,
+      },
+      R2: {
+        chipId: "R2",
+        pins: ["R2.1", "R2.2"],
+        size: { x: 0.5, y: 1 },
+        availableRotations: [0],
+        isResistor: true,
+      },
+      SJ1: {
+        chipId: "SJ1",
+        pins: ["SJ1.1", "SJ1.2", "SJ1.RAIL"],
+        size: carrierSize,
+        availableRotations: rotations,
+      },
+      ...(obstaclePosition && {
+        OBS: {
+          chipId: "OBS",
+          pins: [],
+          size: { x: 0.2, y: 0.2 },
+          availableRotations: [0],
+          fixedPosition: obstaclePosition,
+        },
+      }),
+    },
+    chipPinMap: {
+      "U1.1": { pinId: "U1.1", side: "x-", offset: { x: -1, y: 0.2 } },
+      "U1.2": { pinId: "U1.2", side: "x-", offset: { x: -1, y: 0 } },
+      "U1.3": { pinId: "U1.3", side: "x+", offset: { x: 1, y: -0.2 } },
+      "U1.4": { pinId: "U1.4", side: "x+", offset: { x: 1, y: 0.2 } },
+      "R1.1": { pinId: "R1.1", side: "y+", offset: { x: 0, y: 0.5 } },
+      "R1.2": { pinId: "R1.2", side: "y-", offset: { x: 0, y: -0.5 } },
+      "R2.1": { pinId: "R2.1", side: "y+", offset: { x: 0, y: 0.5 } },
+      "R2.2": { pinId: "R2.2", side: "y-", offset: { x: 0, y: -0.5 } },
+      "SJ1.1": {
+        pinId: "SJ1.1",
+        side: "x-",
+        offset: { x: 0.65, y: 0.2 },
+      },
+      "SJ1.2": {
+        pinId: "SJ1.2",
+        side: "x-",
+        offset: { x: 0.65, y: -0.2 },
+      },
+      "SJ1.RAIL": {
+        pinId: "SJ1.RAIL",
+        side: "x+",
+        offset: { x: 0, y: 0 },
+      },
+    },
+    netMap: { RAIL: { netId: "RAIL" } },
+    pinStrongConnMap: {
+      "U1.4-R1.1": true,
+      "U1.3-R2.1": true,
+      "R1.2-SJ1.1": true,
+      "R2.2-SJ1.2": true,
+    },
+    netConnMap: { "SJ1.RAIL-RAIL": true },
+    chipGap: 0.4,
+    partitionGap: 1.2,
+  }
+
+  return {
+    inputProblem,
+    baseLayout: {
+      chipPlacements: {
+        U1: { x: 0, y: 0, ccwRotationDegrees: 0 },
+        R1: { x: 7, y: 7, ccwRotationDegrees: 0 },
+        R2: { x: 8, y: 7, ccwRotationDegrees: 0 },
+        SJ1: { x: 9, y: 7, ccwRotationDegrees: 0 },
+        ...(obstaclePosition && {
+          OBS: {
+            x: obstaclePosition.x,
+            y: obstaclePosition.y,
+            ccwRotationDegrees: 0,
+          },
+        }),
+      },
+      groupPlacements: {},
+    },
+  }
+}
+
 const expectPlacementToEqual = (
   actual: Placement,
   expected: Placement,
@@ -1355,6 +1464,64 @@ test("accepted rail-carrier reflow satisfies chipGap for every moved pair", () =
   ])
   for (const { distance } of distances) {
     expect(distance).toBeGreaterThanOrEqual(inputProblem.chipGap - 1e-6)
+  }
+})
+
+test("retries rail-carrier rotations after the preferred candidate violates chipGap", () => {
+  const preferredOnly = makeRailCarrierRotationRetryProblem({
+    rotations: [0],
+  })
+  const preferredOnlyLayout = alignRailCarrierFromPackedLayout(
+    preferredOnly.inputProblem,
+    preferredOnly.baseLayout,
+  )
+  expectPlacementToEqual(
+    preferredOnlyLayout.chipPlacements.SJ1!,
+    preferredOnly.baseLayout.chipPlacements.SJ1!,
+  )
+
+  const { inputProblem, baseLayout } = makeRailCarrierRotationRetryProblem({
+    rotations: [0, 90],
+  })
+  const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
+
+  expect(layout.chipPlacements.SJ1!.ccwRotationDegrees).toBe(90)
+  expect(layout.chipPlacements.SJ1!.x).toBeCloseTo(3.800001)
+  expect(layout.chipPlacements.SJ1!.y).toBeCloseTo(-1.65)
+  for (const chipId of ["R1", "R2", "SJ1"]) {
+    expect(layout.chipPlacements[chipId]).not.toEqual(
+      baseLayout.chipPlacements[chipId],
+    )
+  }
+  for (const { distance } of getDistancesFromMovedGroup(inputProblem, layout)) {
+    expect(distance).toBeGreaterThanOrEqual(inputProblem.chipGap - 1e-6)
+  }
+})
+
+test("keeps scored rail-carrier rotation order when earlier input rotations are also clear", () => {
+  const { inputProblem, baseLayout } = makeRailCarrierRotationRetryProblem({
+    rotations: [90, 0],
+    obstaclePosition: null,
+  })
+  const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
+
+  expect(layout.chipPlacements.SJ1!.ccwRotationDegrees).toBe(0)
+  expect(layout.chipPlacements.SJ1!.x).toBeCloseTo(3.350001)
+  expect(layout.chipPlacements.SJ1!.y).toBeCloseTo(-1)
+})
+
+test("keeps rail-carrier group packed when every retried rotation violates chipGap", () => {
+  const { inputProblem, baseLayout } = makeRailCarrierRotationRetryProblem({
+    rotations: [0, 90],
+    obstaclePosition: { x: 3.925001, y: -0.95 },
+  })
+  const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
+
+  for (const chipId of ["R1", "R2", "SJ1"]) {
+    expectPlacementToEqual(
+      layout.chipPlacements[chipId]!,
+      baseLayout.chipPlacements[chipId]!,
+    )
   }
 })
 

--- a/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
+++ b/tests/PackInnerPartitionsSolver/findSameSidePassiveGroups.test.ts
@@ -669,7 +669,7 @@ const makeRailCarrierObstacleProblem = ({
   }
 }
 
-const makeRailCarrierRotationRetryProblem = ({
+const makeRailCarrierBlockedPlacementProblem = ({
   rotations = [0, 90],
   carrierSize = { x: 0.3, y: 1.2 },
   obstaclePosition = { x: 3.925001, y: -0.25 },
@@ -688,7 +688,6 @@ const makeRailCarrierRotationRetryProblem = ({
         pins: ["U1.1", "U1.2", "U1.3", "U1.4"],
         size: { x: 1.2, y: 0.8 },
         availableRotations: [0],
-        fixedPosition: { x: 0, y: 0 },
       },
       R1: {
         chipId: "R1",
@@ -898,435 +897,126 @@ test("detects rail-carrier topology with arbitrary component ids", () => {
   expect(groups[0]!.passiveChipIds).toEqual(["pullup_lower", "pullup_upper"])
 })
 
-test("detects rail-carrier topology around a fixed main chip", () => {
-  const groups = findSameSidePassiveGroups(
-    makeRailCarrierProblem({ fixedMain: true }),
+test("detects rail-carrier topology after record reordering", () => {
+  const inputProblem = makeRailCarrierProblem()
+  inputProblem.chipMap = Object.fromEntries(
+    Object.entries(inputProblem.chipMap).reverse(),
+  )
+  inputProblem.chipPinMap = Object.fromEntries(
+    Object.entries(inputProblem.chipPinMap).reverse(),
+  )
+  inputProblem.pinStrongConnMap = Object.fromEntries(
+    Object.entries(inputProblem.pinStrongConnMap).reverse(),
+  )
+  inputProblem.netConnMap = Object.fromEntries(
+    Object.entries(inputProblem.netConnMap).reverse(),
   )
 
+  const groups = findSameSidePassiveGroups(inputProblem)
+
   expect(groups).toHaveLength(1)
-  expect(groups[0]!.mainChipId).toBe("U1")
-  expect(groups[0]!.railCarrier?.carrierChipId).toBe("SJ1")
   expect(groups[0]!.passiveChipIds).toEqual(["R2", "R1"])
 })
 
-test("reflows rail-carrier passives around fixed main chips without moving them", () => {
-  const cases = [
-    { fixedMainPosition: { x: 0, y: 0 }, fixedMainRotation: 0 },
-    { fixedMainPosition: { x: 10, y: 5 }, fixedMainRotation: 0 },
-    { fixedMainPosition: { x: -7, y: -4 }, fixedMainRotation: 0 },
-    { fixedMainPosition: { x: 100, y: -80 }, fixedMainRotation: 0 },
-    { fixedMainPosition: { x: 0, y: 0 }, fixedMainRotation: 90 },
-    { fixedMainPosition: { x: 0, y: 0 }, fixedMainRotation: 180 },
-    { fixedMainPosition: { x: 0, y: 0 }, fixedMainRotation: 270 },
-  ] as const
-
-  for (const testCase of cases) {
-    const inputProblem = makeRailCarrierProblem({
-      fixedMain: true,
-      fixedMainPosition: testCase.fixedMainPosition,
-      fixedMainRotation: testCase.fixedMainRotation,
-    })
-    const solver = new LayoutPipelineSolver(inputProblem)
-    solver.solve()
-    const layout = solver.getOutputLayout()
-
-    expect(
-      solver.packInnerPartitionsSolver?.completedSolvers[0]?.constructor.name,
-    ).toBe("ParallelAlignedPassiveSolver")
-    expectPlacementToEqual(layout.chipPlacements.U1!, {
-      ...testCase.fixedMainPosition,
-      ccwRotationDegrees: testCase.fixedMainRotation,
-    })
-    expect(solver.checkForOverlaps(layout)).toHaveLength(0)
-    for (const { distance } of getDistancesFromMovedGroup(
-      inputProblem,
-      layout,
-    )) {
-      expect(distance).toBeGreaterThanOrEqual(inputProblem.chipGap - 1e-6)
-    }
+test("declines unsupported rail-carrier topology variants", () => {
+  const mutateRailCarrierProblem = (
+    mutate: (inputProblem: InputProblem) => void,
+  ) => {
+    const inputProblem = makeRailCarrierProblem()
+    mutate(inputProblem)
+    return inputProblem
   }
-})
-
-test("uses fixed main-chip rotation when ordering rail-carrier passives", () => {
-  const groups = findSameSidePassiveGroups(
-    makeRailCarrierProblem({ fixedMain: true, fixedMainRotation: 90 }),
-  )
-
-  expect(groups).toHaveLength(1)
-  expect(groups[0]!.side).toBe("y+")
-  expect(groups[0]!.passiveChipIds).toEqual(["R1", "R2"])
-  expect(groups[0]!.mainChipPinIds).toEqual(["U1.4", "U1.3"])
-})
-
-test("declines rail-carrier topology when a resistor main-facing pin is branched", () => {
-  expect(
-    findSameSidePassiveGroups(
-      makeRailCarrierProblem({ branchedMainFacingPin: true }),
-    ),
-  ).toHaveLength(0)
-  expect(
-    findSameSidePassiveGroups(
-      makeRailCarrierProblem({
-        branchedMainFacingPin: true,
-        customIds: true,
-      }),
-    ),
-  ).toHaveLength(0)
-
-  const renamedOrderVariant = makeRailCarrierProblem({
-    branchedMainFacingPin: true,
-    customIds: true,
-  })
-  renamedOrderVariant.pinStrongConnMap = Object.fromEntries(
-    Object.entries(renamedOrderVariant.pinStrongConnMap).reverse(),
-  )
-  expect(findSameSidePassiveGroups(renamedOrderVariant)).toHaveLength(0)
-})
-
-test("declines rail-carrier topology when a resistor carrier-facing pin is branched", () => {
-  expect(
-    findSameSidePassiveGroups(
-      makeRailCarrierProblem({ branchedCarrierFacingPin: true }),
-    ),
-  ).toHaveLength(0)
-})
-
-test("declines fixed-main rail-carrier topology when a resistor pin is branched", () => {
-  expect(
-    findSameSidePassiveGroups(
-      makeRailCarrierProblem({
-        fixedMain: true,
-        branchedMainFacingPin: true,
-      }),
-    ),
-  ).toHaveLength(0)
-})
-
-test("enforces rail-carrier identity and cardinality invariants", () => {
-  const cases: Array<{
-    name: string
-    mutate: (inputProblem: InputProblem) => void
-    expectedRailGroups: number
-  }> = [
+  const cases: Array<{ name: string; inputProblem: InputProblem }> = [
     {
-      name: "duplicate main pin",
-      mutate: (inputProblem) => {
-        replaceStrongConnection(inputProblem, "Uwide.2-R2.1", "Uwide.1-R2.1")
-      },
-      expectedRailGroups: 0,
+      name: "three resistors",
+      inputProblem: makeMultiPassiveRailCarrierProblem({ passiveCount: 3 }),
     },
     {
-      name: "all resistors share one main pin",
-      mutate: (inputProblem) => {
-        replaceStrongConnection(inputProblem, "Uwide.2-R2.1", "Uwide.1-R2.1")
-        replaceStrongConnection(inputProblem, "Uwide.3-R3.1", "Uwide.1-R3.1")
-      },
-      expectedRailGroups: 0,
+      name: "four resistors",
+      inputProblem: makeMultiPassiveRailCarrierProblem({ passiveCount: 4 }),
     },
     {
-      name: "duplicate carrier pin",
-      mutate: (inputProblem) => {
-        replaceStrongConnection(inputProblem, "R2.2-Jwide.2", "R2.2-Jwide.1")
-      },
-      expectedRailGroups: 0,
+      name: "five resistors",
+      inputProblem: makeMultiPassiveRailCarrierProblem({ passiveCount: 5 }),
     },
     {
-      name: "all resistors share one carrier pin",
-      mutate: (inputProblem) => {
-        replaceStrongConnection(inputProblem, "R2.2-Jwide.2", "R2.2-Jwide.1")
-        replaceStrongConnection(inputProblem, "R3.2-Jwide.3", "R3.2-Jwide.1")
-      },
-      expectedRailGroups: 0,
+      name: "four-pin carrier",
+      inputProblem: makeRailCarrierProblem({ multipleRailPins: true }),
     },
     {
-      name: "different main chip",
-      mutate: (inputProblem) => {
-        inputProblem.chipMap.Uother = {
-          chipId: "Uother",
-          pins: ["Uother.1", "Uother.2", "Uother.3", "Uother.4"],
-          size: { x: 1.6, y: 1.6 },
-          availableRotations: [0, 90, 180, 270],
-        }
-        inputProblem.chipPinMap["Uother.1"] = {
-          pinId: "Uother.1",
-          side: "x+",
-          offset: { x: 1, y: 0 },
-        }
-        replaceStrongConnection(inputProblem, "Uwide.3-R3.1", "Uother.1-R3.1")
-      },
-      expectedRailGroups: 0,
-    },
-    {
-      name: "different carrier chip",
-      mutate: (inputProblem) => {
-        inputProblem.chipMap.Jother = {
-          chipId: "Jother",
-          pins: ["Jother.1", "Jother.RAIL"],
-          size: { x: 0.8, y: 0.8 },
-          availableRotations: [0, 90, 180, 270],
-        }
-        inputProblem.chipPinMap["Jother.1"] = {
-          pinId: "Jother.1",
-          side: "x-",
-          offset: { x: -0.4, y: 0 },
-        }
-        inputProblem.chipPinMap["Jother.RAIL"] = {
-          pinId: "Jother.RAIL",
-          side: "y+",
-          offset: { x: 0, y: 0.4 },
-        }
-        inputProblem.netConnMap["Jother.RAIL-RAIL"] = true
-        replaceStrongConnection(inputProblem, "R3.2-Jwide.3", "R3.2-Jother.1")
-      },
-      expectedRailGroups: 0,
-    },
-    {
-      name: "same main and carrier chip",
-      mutate: (inputProblem) => {
-        replaceStrongConnection(inputProblem, "R1.2-Jwide.1", "R1.2-Uwide.4")
-      },
-      expectedRailGroups: 0,
-    },
-    {
-      name: "main-facing branch",
-      mutate: (inputProblem) => {
-        inputProblem.chipMap.TP1 = {
-          chipId: "TP1",
-          pins: ["TP1.1"],
-          size: { x: 0.2, y: 0.2 },
-          availableRotations: [0],
-        }
-        inputProblem.chipPinMap["TP1.1"] = {
-          pinId: "TP1.1",
-          side: "x+",
-          offset: { x: 0.1, y: 0 },
-        }
-        inputProblem.pinStrongConnMap["R1.1-TP1.1"] = true
-      },
-      expectedRailGroups: 0,
-    },
-    {
-      name: "carrier-facing branch",
-      mutate: (inputProblem) => {
-        inputProblem.chipMap.TP1 = {
-          chipId: "TP1",
-          pins: ["TP1.1"],
-          size: { x: 0.2, y: 0.2 },
-          availableRotations: [0],
-        }
-        inputProblem.chipPinMap["TP1.1"] = {
-          pinId: "TP1.1",
-          side: "x+",
-          offset: { x: 0.1, y: 0 },
-        }
-        inputProblem.pinStrongConnMap["R1.2-TP1.1"] = true
-      },
-      expectedRailGroups: 0,
-    },
-    {
-      name: "carrier claimed pin branch",
-      mutate: (inputProblem) => {
-        inputProblem.chipMap.TP1 = {
-          chipId: "TP1",
-          pins: ["TP1.1"],
-          size: { x: 0.2, y: 0.2 },
-          availableRotations: [0],
-        }
-        inputProblem.chipPinMap["TP1.1"] = {
-          pinId: "TP1.1",
-          side: "x+",
-          offset: { x: 0.1, y: 0 },
-        }
-        inputProblem.pinStrongConnMap["Jwide.1-TP1.1"] = true
-      },
-      expectedRailGroups: 0,
-    },
-    {
-      name: "extra unexplained carrier pin",
-      mutate: (inputProblem) => {
-        inputProblem.chipMap.Jwide!.pins.push("Jwide.NC")
-        inputProblem.chipPinMap["Jwide.NC"] = {
-          pinId: "Jwide.NC",
-          side: "y-",
-          offset: { x: 0, y: -0.4 },
-        }
-      },
-      expectedRailGroups: 0,
-    },
-    {
-      name: "zero rail pins",
-      mutate: (inputProblem) => {
-        inputProblem.netConnMap = {}
-      },
-      expectedRailGroups: 0,
-    },
-    {
-      name: "multiple rail pins",
-      mutate: (inputProblem) => {
-        inputProblem.chipMap.Jwide!.pins.push("Jwide.RAIL2")
-        inputProblem.chipPinMap["Jwide.RAIL2"] = {
-          pinId: "Jwide.RAIL2",
-          side: "y+",
-          offset: { x: 0.2, y: 0.4 },
-        }
-        inputProblem.netMap.RAIL2 = { netId: "RAIL2" }
-        inputProblem.netConnMap["Jwide.RAIL2-RAIL2"] = true
-      },
-      expectedRailGroups: 0,
-    },
-    {
-      name: "rail pin with ambiguous net membership",
-      mutate: (inputProblem) => {
-        inputProblem.netMap.OTHER = { netId: "OTHER" }
-        inputProblem.netConnMap["Jwide.RAIL-OTHER"] = true
-      },
-      expectedRailGroups: 0,
-    },
-    {
-      name: "partial carrier accounting",
-      mutate: (inputProblem) => {
-        delete inputProblem.pinStrongConnMap["R3.2-Jwide.3"]
-      },
-      expectedRailGroups: 0,
-    },
-    {
-      name: "mixed main-chip side",
-      mutate: (inputProblem) => {
-        inputProblem.chipPinMap["Uwide.3"] = {
-          pinId: "Uwide.3",
-          side: "x-",
-          offset: { x: -1, y: 0.2 },
-        }
-      },
-      expectedRailGroups: 0,
-    },
-    {
-      name: "same-side distinct pins with identical edge coordinate",
-      mutate: (inputProblem) => {
-        inputProblem.chipPinMap["Uwide.2"] = {
-          ...inputProblem.chipPinMap["Uwide.2"]!,
-          offset: { ...inputProblem.chipPinMap["Uwide.1"]!.offset },
-        }
-      },
-      expectedRailGroups: 0,
+      name: "fixed main",
+      inputProblem: makeRailCarrierProblem({ fixedMain: true }),
     },
     {
       name: "fixed resistor",
-      mutate: (inputProblem) => {
-        inputProblem.chipMap.R1!.fixedPosition = { x: 2, y: 1 }
-      },
-      expectedRailGroups: 0,
+      inputProblem: makeRailCarrierProblem({ fixedPassive: true }),
     },
     {
       name: "fixed carrier",
-      mutate: (inputProblem) => {
-        inputProblem.chipMap.Jwide!.fixedPosition = { x: 3, y: 0 }
-      },
-      expectedRailGroups: 0,
+      inputProblem: makeRailCarrierProblem({ fixedCarrier: true }),
     },
     {
-      name: "fixed main remains valid",
-      mutate: (inputProblem) => {
-        inputProblem.chipMap.Uwide!.fixedPosition = { x: 0, y: 0 }
-      },
-      expectedRailGroups: 1,
+      name: "duplicate main pin",
+      inputProblem: mutateRailCarrierProblem((inputProblem) => {
+        replaceStrongConnection(inputProblem, "U1.3-R2.1", "U1.4-R2.1")
+      }),
     },
     {
-      name: "reordered maps remain valid",
-      mutate: (inputProblem) => {
-        inputProblem.chipMap = reorderRecord(inputProblem.chipMap)
-        inputProblem.chipPinMap = reorderRecord(inputProblem.chipPinMap)
-        inputProblem.pinStrongConnMap = reorderRecord(
-          inputProblem.pinStrongConnMap,
-        )
-        inputProblem.netConnMap = reorderRecord(inputProblem.netConnMap)
-      },
-      expectedRailGroups: 1,
+      name: "duplicate carrier pin",
+      inputProblem: mutateRailCarrierProblem((inputProblem) => {
+        replaceStrongConnection(inputProblem, "SJ1.1-R2.2", "SJ1.3-R2.2")
+      }),
+    },
+    {
+      name: "branched main-facing pin",
+      inputProblem: makeRailCarrierProblem({ branchedMainFacingPin: true }),
+    },
+    {
+      name: "branched carrier-facing pin",
+      inputProblem: makeRailCarrierProblem({ branchedCarrierFacingPin: true }),
+    },
+    {
+      name: "no rail pin",
+      inputProblem: mutateRailCarrierProblem((inputProblem) => {
+        inputProblem.netConnMap = {}
+      }),
+    },
+    {
+      name: "rail pin with two nets",
+      inputProblem: mutateRailCarrierProblem((inputProblem) => {
+        inputProblem.netMap.OTHER = { netId: "OTHER" }
+        inputProblem.netConnMap["SJ1.2-OTHER"] = true
+      }),
+    },
+    {
+      name: "untyped passive",
+      inputProblem: mutateRailCarrierProblem((inputProblem) => {
+        inputProblem.chipMap.R1!.isResistor = false
+      }),
+    },
+    {
+      name: "non-two-pin passive",
+      inputProblem: mutateRailCarrierProblem((inputProblem) => {
+        inputProblem.chipMap.R1!.pins.push("R1.3")
+        inputProblem.chipPinMap["R1.3"] = {
+          pinId: "R1.3",
+          side: "x+",
+          offset: { x: 0.25, y: 0 },
+        }
+      }),
+    },
+    {
+      name: "different carriers",
+      inputProblem: makeRailCarrierProblem({ differentCarriers: true }),
     },
   ]
 
   for (const testCase of cases) {
-    const groups = getRailCarrierGroups(
-      makeRailCarrierContractProblem(testCase.mutate),
-    )
-    expect(groups, testCase.name).toHaveLength(testCase.expectedRailGroups)
-    if (testCase.expectedRailGroups === 1) {
-      expect(groups[0]!.passiveChipIds, testCase.name).toEqual([
-        "R1",
-        "R2",
-        "R3",
-      ])
-    }
+    expect(
+      getRailCarrierGroups(testCase.inputProblem),
+      testCase.name,
+    ).toHaveLength(0)
   }
-})
-
-test("declines mirrored or overlapping rail-carrier membership ambiguity", () => {
-  expect(getRailCarrierGroups(makeMirroredRailCarrierProblem())).toHaveLength(0)
-
-  const overlappingCarrierProblem = makeRailCarrierContractProblem(
-    (inputProblem) => {
-      inputProblem.chipMap.Jother = {
-        chipId: "Jother",
-        pins: ["Jother.1", "Jother.2", "Jother.RAIL"],
-        size: { x: 0.8, y: 0.8 },
-        availableRotations: [0, 90, 180, 270],
-      }
-      inputProblem.chipPinMap["Jother.1"] = {
-        pinId: "Jother.1",
-        side: "x-",
-        offset: { x: -0.4, y: -0.1 },
-      }
-      inputProblem.chipPinMap["Jother.2"] = {
-        pinId: "Jother.2",
-        side: "x-",
-        offset: { x: -0.4, y: 0.1 },
-      }
-      inputProblem.chipPinMap["Jother.RAIL"] = {
-        pinId: "Jother.RAIL",
-        side: "y+",
-        offset: { x: 0, y: 0.4 },
-      }
-      inputProblem.netConnMap["Jother.RAIL-RAIL"] = true
-      inputProblem.pinStrongConnMap["R2.2-Jother.1"] = true
-      replaceStrongConnection(inputProblem, "R3.2-Jwide.3", "R3.2-Jother.2")
-    },
-  )
-
-  expect(getRailCarrierGroups(overlappingCarrierProblem)).toHaveLength(0)
-})
-
-test("detects four-passive rail-carrier topology without a pin-count ceiling", () => {
-  const groups = findSameSidePassiveGroups(
-    makeMultiPassiveRailCarrierProblem({ passiveCount: 4 }),
-  )
-
-  expect(groups).toHaveLength(1)
-  expect(groups[0]!.railCarrier?.carrierChipId).toBe("Jwide")
-  expect(groups[0]!.passiveChipIds).toEqual(["R1", "R2", "R3", "R4"])
-})
-
-test("detects five-passive rail-carrier topology by exact carrier pin roles", () => {
-  const groups = findSameSidePassiveGroups(
-    makeMultiPassiveRailCarrierProblem({ passiveCount: 5 }),
-  )
-
-  expect(groups).toHaveLength(1)
-  expect(groups[0]!.railCarrier?.carrierChipId).toBe("Jwide")
-  expect(groups[0]!.passiveChipIds).toEqual(["R1", "R2", "R3", "R4", "R5"])
-})
-
-test("declines symmetric mirrored rail-carrier topology", () => {
-  const groups = findSameSidePassiveGroups(makeMirroredRailCarrierProblem())
-
-  expect(groups).toHaveLength(0)
-})
-
-test("declines mirrored rail-carrier topology when mirrored endpoints are fixed", () => {
-  const problem = makeMirroredRailCarrierProblem()
-  problem.chipMap.A!.fixedPosition = { x: 0, y: 0 }
-  problem.chipMap.B!.fixedPosition = { x: 4, y: 0 }
-
-  expect(findSameSidePassiveGroups(problem)).toHaveLength(0)
 })
 
 test("keeps dense rail-carrier passives at least chipGap apart", () => {
@@ -1343,26 +1033,6 @@ test("keeps dense rail-carrier passives at least chipGap apart", () => {
   expect(getBoundsDistance(r1Bounds, r2Bounds)).toBeGreaterThanOrEqual(
     inputProblem.chipGap - 1e-6,
   )
-})
-
-test("keeps dense fixed-main rail-carrier passives at least chipGap apart", () => {
-  const inputProblem = makeDenseRailCarrierGapProblem()
-  inputProblem.chipMap.U1!.fixedPosition = { x: 0, y: 0 }
-  const solver = new LayoutPipelineSolver(inputProblem)
-  solver.solve()
-  const layout = solver.getOutputLayout()
-
-  expect(
-    solver.packInnerPartitionsSolver?.completedSolvers[0]?.constructor.name,
-  ).toBe("ParallelAlignedPassiveSolver")
-  expectPlacementToEqual(layout.chipPlacements.U1!, {
-    x: 0,
-    y: 0,
-    ccwRotationDegrees: 0,
-  })
-  for (const { distance } of getDistancesFromMovedGroup(inputProblem, layout)) {
-    expect(distance).toBeGreaterThanOrEqual(inputProblem.chipGap - 1e-6)
-  }
 })
 
 test("rejects rail-carrier reflow that would violate chipGap to an unrelated obstacle", () => {
@@ -1399,50 +1069,6 @@ test("rejects rail-carrier reflow that would violate chipGap to an unrelated obs
   }
 })
 
-test("fixed-main obstacle fallback leaves the main and rail group atomically packed", () => {
-  const { inputProblem, baseLayout } = makeRailCarrierObstacleProblem({
-    targetChipId: "R2",
-    clearance: 0.1,
-  })
-  inputProblem.chipMap.U1!.fixedPosition = { x: 0, y: 0 }
-  const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
-
-  for (const chipId of ["U1", "R1", "R2", "SJ1"]) {
-    expectPlacementToEqual(
-      layout.chipPlacements[chipId]!,
-      baseLayout.chipPlacements[chipId]!,
-    )
-  }
-})
-
-test("rail-carrier obstacle boundary preserves chipGap semantics", () => {
-  const cases = [
-    { clearance: 0.1, chipGap: 0.5, shouldAccept: false },
-    { clearance: 0.499, chipGap: 0.5, shouldAccept: false },
-    { clearance: 0.5, chipGap: 0.5, shouldAccept: true },
-    { clearance: 0.6, chipGap: 0.5, shouldAccept: true },
-    { clearance: 0.1, chipGap: 0, shouldAccept: true },
-  ]
-
-  for (const testCase of cases) {
-    const { inputProblem, baseLayout, unobstructedLayout } =
-      makeRailCarrierObstacleProblem({
-        targetChipId: "SJ1",
-        clearance: testCase.clearance,
-        chipGap: testCase.chipGap,
-      })
-    const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
-
-    for (const chipId of ["R1", "R2", "SJ1"]) {
-      expectPlacementToEqual(
-        layout.chipPlacements[chipId]!,
-        (testCase.shouldAccept ? unobstructedLayout : baseLayout)
-          .chipPlacements[chipId]!,
-      )
-    }
-  }
-})
-
 test("accepted rail-carrier reflow satisfies chipGap for every moved pair", () => {
   const { inputProblem, baseLayout } = makeRailCarrierObstacleProblem({
     targetChipId: "SJ1",
@@ -1467,53 +1093,9 @@ test("accepted rail-carrier reflow satisfies chipGap for every moved pair", () =
   }
 })
 
-test("retries rail-carrier rotations after the preferred candidate violates chipGap", () => {
-  const preferredOnly = makeRailCarrierRotationRetryProblem({
-    rotations: [0],
-  })
-  const preferredOnlyLayout = alignRailCarrierFromPackedLayout(
-    preferredOnly.inputProblem,
-    preferredOnly.baseLayout,
-  )
-  expectPlacementToEqual(
-    preferredOnlyLayout.chipPlacements.SJ1!,
-    preferredOnly.baseLayout.chipPlacements.SJ1!,
-  )
-
-  const { inputProblem, baseLayout } = makeRailCarrierRotationRetryProblem({
-    rotations: [0, 90],
-  })
-  const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
-
-  expect(layout.chipPlacements.SJ1!.ccwRotationDegrees).toBe(90)
-  expect(layout.chipPlacements.SJ1!.x).toBeCloseTo(3.800001)
-  expect(layout.chipPlacements.SJ1!.y).toBeCloseTo(-1.65)
-  for (const chipId of ["R1", "R2", "SJ1"]) {
-    expect(layout.chipPlacements[chipId]).not.toEqual(
-      baseLayout.chipPlacements[chipId],
-    )
-  }
-  for (const { distance } of getDistancesFromMovedGroup(inputProblem, layout)) {
-    expect(distance).toBeGreaterThanOrEqual(inputProblem.chipGap - 1e-6)
-  }
-})
-
-test("keeps scored rail-carrier rotation order when earlier input rotations are also clear", () => {
-  const { inputProblem, baseLayout } = makeRailCarrierRotationRetryProblem({
-    rotations: [90, 0],
-    obstaclePosition: null,
-  })
-  const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
-
-  expect(layout.chipPlacements.SJ1!.ccwRotationDegrees).toBe(0)
-  expect(layout.chipPlacements.SJ1!.x).toBeCloseTo(3.350001)
-  expect(layout.chipPlacements.SJ1!.y).toBeCloseTo(-1)
-})
-
-test("keeps rail-carrier group packed when every retried rotation violates chipGap", () => {
-  const { inputProblem, baseLayout } = makeRailCarrierRotationRetryProblem({
-    rotations: [0, 90],
-    obstaclePosition: { x: 3.925001, y: -0.95 },
+test("does not retry another carrier rotation when the unique one is unsafe", () => {
+  const { inputProblem, baseLayout } = makeRailCarrierBlockedPlacementProblem({
+    rotations: [270],
   })
   const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
 
@@ -1525,121 +1107,66 @@ test("keeps rail-carrier group packed when every retried rotation violates chipG
   }
 })
 
-test("reflows rail-carrier groups using the actual packed main-chip rotation", () => {
-  const inputProblem = makeRotatedPackedMainRailCarrierProblem()
-  const detectedGroups = findSameSidePassiveGroups(inputProblem)
-  const solver = new LayoutPipelineSolver(inputProblem)
-  solver.solve()
-  const layout = solver.getOutputLayout()
-  const mainPlacement = layout.chipPlacements.A!
-  const mainBounds = getChipBounds(inputProblem, "A", mainPlacement)
+test("uses the actual packed main rotation for rail-carrier side and order", () => {
+  const inputProblem = makeRailCarrierProblem()
+  const baseLayout = makeRailCarrierPackedLayout()
+  baseLayout.chipPlacements.U1 = { x: 0, y: 0, ccwRotationDegrees: 90 }
+  const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
+  const mainBounds = getChipBounds(
+    inputProblem,
+    "U1",
+    layout.chipPlacements.U1!,
+  )
 
-  expect(detectedGroups).toHaveLength(1)
-  expect(detectedGroups[0]!.side).toBe("y+")
-  expect(mainPlacement.ccwRotationDegrees).toBe(90)
-  for (const passiveChipId of ["R1", "R2", "R3", "R4"]) {
-    const passiveBounds = getChipBounds(
+  expect(layout.chipPlacements.SJ1!.ccwRotationDegrees).toBe(0)
+  for (const passiveChipId of ["R1", "R2", "SJ1"]) {
+    const bounds = getChipBounds(
       inputProblem,
       passiveChipId,
       layout.chipPlacements[passiveChipId]!,
     )
-    expect(passiveBounds.maxX).toBeLessThanOrEqual(
-      mainBounds.minX - inputProblem.chipGap + 1e-6,
+    expect(bounds.minY).toBeGreaterThanOrEqual(
+      mainBounds.maxY + inputProblem.chipGap - 1e-6,
     )
   }
 })
 
-test("declines rail-carrier topology for diode-like or untyped leaves", () => {
-  expect(
-    findSameSidePassiveGroups(
-      makeMultiPassiveRailCarrierProblem({ diodeLikeFirstPassive: true }),
-    ),
-  ).toHaveLength(0)
-  expect(
-    findSameSidePassiveGroups(
-      makeMultiPassiveRailCarrierProblem({ untypedFirstPassive: true }),
-    ),
-  ).toHaveLength(0)
+test("fails closed for reversed or ambiguous carrier pin ordering", () => {
+  const reversed = makeRailCarrierProblem()
+  reversed.chipMap.SJ1!.availableRotations = [90]
+
+  const ambiguous = makeRailCarrierProblem()
+  ambiguous.chipMap.SJ1!.availableRotations = [0, 90]
+  ambiguous.chipPinMap["SJ1.1"] = {
+    ...ambiguous.chipPinMap["SJ1.1"]!,
+    offset: { x: -0.3, y: -0.3 },
+  }
+  ambiguous.chipPinMap["SJ1.3"] = {
+    ...ambiguous.chipPinMap["SJ1.3"]!,
+    offset: { x: 0.3, y: 0.3 },
+  }
+
+  for (const inputProblem of [reversed, ambiguous]) {
+    const baseLayout = makeRailCarrierPackedLayout()
+    const layout = alignRailCarrierFromPackedLayout(inputProblem, baseLayout)
+    for (const chipId of ["R1", "R2", "SJ1"]) {
+      expectPlacementToEqual(
+        layout.chipPlacements[chipId]!,
+        baseLayout.chipPlacements[chipId]!,
+      )
+    }
+  }
 })
 
-test("declines rail-carrier topology for non-two-pin passive leaves", () => {
-  expect(
-    findSameSidePassiveGroups(
-      makeMultiPassiveRailCarrierProblem({ transistorLikeFirstPassive: true }),
-    ),
-  ).toHaveLength(0)
-})
+test("rail-carrier reflow is deterministic", () => {
+  const results = new Set<string>()
+  for (let i = 0; i < 20; i++) {
+    const solver = new LayoutPipelineSolver(si7021Input as InputProblem)
+    solver.solve()
+    results.add(JSON.stringify(solver.getOutputLayout().chipPlacements))
+  }
 
-test("declines same-side passives attached to unrelated downstream parts", () => {
-  expect(
-    findSameSidePassiveGroups(
-      makeRailCarrierProblem({ differentCarriers: true }),
-    ),
-  ).toHaveLength(0)
-})
-
-test("declines a shared carrier with an extra branch", () => {
-  expect(
-    findSameSidePassiveGroups(
-      makeRailCarrierProblem({ ambiguousCarrierBranch: true }),
-    ),
-  ).toHaveLength(0)
-})
-
-test("declines a shared carrier with multiple possible rail pins", () => {
-  expect(
-    findSameSidePassiveGroups(
-      makeRailCarrierProblem({ multipleRailPins: true }),
-    ),
-  ).toHaveLength(0)
-})
-
-test("declines larger carriers with unexplained pins or branches", () => {
-  expect(
-    findSameSidePassiveGroups(
-      makeMultiPassiveRailCarrierProblem({ extraBranch: true }),
-    ),
-  ).toHaveLength(0)
-  expect(
-    findSameSidePassiveGroups(
-      makeMultiPassiveRailCarrierProblem({ extraCarrierPin: true }),
-    ),
-  ).toHaveLength(0)
-  expect(
-    findSameSidePassiveGroups(
-      makeMultiPassiveRailCarrierProblem({ largeCarrierLike: true }),
-    ),
-  ).toHaveLength(0)
-})
-
-test("declines four-passive carrier with multiple possible rail pins", () => {
-  expect(
-    findSameSidePassiveGroups(
-      makeMultiPassiveRailCarrierProblem({ multipleRailPins: true }),
-    ),
-  ).toHaveLength(0)
-})
-
-test("declines rail-carrier topology when the carrier is fixed", () => {
-  expect(
-    findSameSidePassiveGroups(makeRailCarrierProblem({ fixedCarrier: true })),
-  ).toHaveLength(0)
-  expect(
-    findSameSidePassiveGroups(
-      makeRailCarrierProblem({ fixedMain: true, fixedCarrier: true }),
-    ),
-  ).toHaveLength(0)
-})
-
-test("declines rail-carrier topology when a passive is fixed", () => {
-  expect(
-    findSameSidePassiveGroups(makeRailCarrierProblem({ fixedPassive: true })),
-  ).toHaveLength(0)
-  expect(
-    findSameSidePassiveGroups(
-      makeRailCarrierProblem({ fixedMain: true, fixedPassive: true }),
-    ),
-  ).toHaveLength(0)
+  expect(results.size).toBe(1)
 })
 
 test("preserves existing common-node passive detection", () => {


### PR DESCRIPTION
## Summary

Fixes the SI7021 layout regression from #11 by adding a deliberately narrow
rail-carrier path for the exact structural family demonstrated there: two
pull-up resistors terminating through a shared three-pin rail carrier.

This is not a broad rail-carrier solver. Unsupported or ambiguous topologies
retain normal generic packing.

## Problem

Current `main` is deterministic and overlap-free for the SI7021 repro, but the
pull-up / jumper chain has visible off-axis zig-zag:

- two resistors connect to adjacent pins on the same side of the main chip
- their opposite pins connect to distinct pins on a shared carrier
- the carrier's remaining pin provides the shared rail connection

Baseline on the original repro:

| Metric | Before |
| --- | ---: |
| Overlaps | 0 |
| Strong edges | 5 |
| Total Manhattan distance | 5.9 |
| Max off-axis error | 0.5 |
| Bent strong edges | 4/5 |

## Supported Scope

The detector requires all of the following:

- exactly two typed movable two-pin resistors
- distinct main-chip pins on the same physical side of one movable main chip
- each participating resistor pin has only the expected strong connection
- both resistors terminate at distinct pins of one movable three-pin carrier
- the carrier's third pin provides the single rail/net connection

Recognition uses graph, pin, component-type, and net connectivity metadata only.

It does not depend on:

- reference designators
- component names
- voltage or net names
- arbitrary global coordinates

Fixed main, fixed resistor, and fixed carrier configurations are intentionally
outside this narrow rail-carrier path and fail closed to generic packing.

## Reflow Policy

The reflow:

- derives the physical side and passive order from the actual packed main-chip
  rotation
- moves the two resistors and the carrier as one semantic group
- requires exactly one carrier rotation whose resistor-facing pins preserve the
  passive order
- fails closed to generic packing when carrier geometry is incompatible or
  ambiguous
- validates overlap and configured `chipGap` safety for the complete moved group
- commits movement atomically only when the complete proposal is safe

There is no score-ranked carrier search and no alternate rotation retry in the
final narrow implementation.

## Result

On the SI7021 repro:

| Metric | Before | After |
| --- | ---: | ---: |
| Overlaps | 0 | 0 |
| Strong edges | 5 | 5 |
| Total Manhattan distance | 5.9 | 5.700002 |
| Total Euclidean distance | - | 5.507951 |
| Max off-axis error | 0.5 | 0.1 |
| Bent strong edges | 4/5 | 2/5 |
| Required `chipGap` | - | 0.4 |

The improvement is reduced off-axis error, fewer bent strong edges, preserved
overlap freedom, preserved `chipGap`, and deterministic output. The Euclidean
distance is reported for the final layout only and is not claimed as an
improvement.

## Regression Coverage

Coverage includes:

- exact SI7021 topology
- renamed structural equivalent
- reordered-map equivalent
- packed-main rotation interpretation
- reversed or incompatible carrier order fails closed
- banks with more than two resistors fail closed
- carriers with more than three pins fail closed
- fixed main, resistor, or carrier configurations fail closed
- duplicate main or carrier anchors fail closed
- branched participating pins fail closed
- invalid rail cardinality fails closed
- obstacle / `chipGap` failure is atomic
- passive-to-carrier pin pairing is preserved when candidate/map enumeration
  order differs from main-edge order
- common-node and ordinary same-side behaviour remains unchanged
- production resistor typing
- representative LayoutPipeline coverage
- deterministic repeated execution

The implementation requires exactly one compatible carrier rotation and
otherwise fails closed.

## Validation

Latest independent narrow QA:

- focused rail-carrier suite: **15 passed**
- relevant integration: **16 passed, 1 skipped**
- `bunx tsc --noEmit`: **passed**
- `bun run format:check`: **passed**
- `bun run build`: **passed**
- full `bun test`: **109 passed, 1 skipped, 1 known unrelated timing-sensitive WLED timeout**
- 48 JSON InputProblems checked
- 0 unexplained corpus differences
- candidate vs parent `673e67a` produced 0 normalized corpus differences
- 20-run SI7021 determinism stable
- P2 #9 candidate-enumeration / carrier-pin pairing regression covered

The full suite's only failure is the known timing-sensitive WLED
iteration-budget test. Control runs on the repaired candidate, its parent, and
the qualified base all exceeded the same 30s threshold; the WLED fixture does
not enter the rail-carrier path.

## AI disclosure

OpenAI Codex assisted with repository analysis, implementation, validation, and
publication preparation. I reviewed the changes, independently validated the
behaviour through a separate QA pass, and take responsibility for the
contribution.

Fixes #12

/claim #12
